### PR TITLE
[3/12] feat: Services Section

### DIFF
--- a/components/headerCustom/headerCustom.tsx
+++ b/components/headerCustom/headerCustom.tsx
@@ -22,6 +22,10 @@ export function HeaderCustom () {
       route: '#about',
     },
     {
+      label: 'Services',
+      route: '#services',
+    },
+    {
       label: 'Compétences',
       route: '#Skills',
     },

--- a/components/headerCustom/headerCustom.tsx
+++ b/components/headerCustom/headerCustom.tsx
@@ -27,29 +27,48 @@ export function HeaderCustom () {
     },
     {
       label: 'Compétences',
-      route: '#Skills',
+      route: '#skills',
     },
     {
       label: 'Expériences professionnelles',
-      route: '#WorkExperience',
+      route: '#workExperiences',
     },
     {
       label: 'Formations',
-      route: '#Educations',
+      route: '#educations',
     },
     {
       label: 'Projets',
-      route: '#Projects',
+      route: '#projects',
     },
     {
       label: 'Contact',
-      route: '#Contact',
+      route: '#contact',
     },
   ];
 
   const router = useRouter();
+  const [activeHash, setActiveHash] = React.useState<string>('');
+
+  React.useEffect(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    const updateHash = () => {
+      setActiveHash(window.location.hash || '');
+    };
+
+    updateHash();
+    window.addEventListener('hashchange', updateHash);
+
+    return () => {
+      window.removeEventListener('hashchange', updateHash);
+    };
+  }, []);
+
   function getSelectedCss(currentRoute: string): string {
-    return currentRoute === router.route ? 'selected' : '';
+    return currentRoute === activeHash ? 'selected' : '';
   }
 
   function forceMenuToClosed(): void {

--- a/components/headerCustom/headerCustom.tsx
+++ b/components/headerCustom/headerCustom.tsx
@@ -2,7 +2,6 @@
 import React from 'react';
 import Link from 'next/link';
 import Image from 'next/image';
-import { useRouter } from 'next/router';
 
 // Images
 import Logo from '../../public/images/header/logo.webp';
@@ -47,7 +46,6 @@ export function HeaderCustom () {
     },
   ];
 
-  const router = useRouter();
   const [activeHash, setActiveHash] = React.useState<string>('');
 
   React.useEffect(() => {

--- a/components/heroSection/heroSection.tsx
+++ b/components/heroSection/heroSection.tsx
@@ -75,7 +75,7 @@ export function HeroSection() {
         <HeroHeadline />
         <p className={styles.promise}>
           Je conçois des applications web robustes, du back&#8209;end&nbsp;.NET
-          à l&apos;interface React/Blazor.
+          à l&apos;interface Blazor.
         </p>
         <HeroProofPoints />
         <HeroActionGroup />

--- a/components/sectionServices/index.tsx
+++ b/components/sectionServices/index.tsx
@@ -1,0 +1,1 @@
+export * from "./sectionServices";

--- a/components/sectionServices/sectionServices.extensions.ts
+++ b/components/sectionServices/sectionServices.extensions.ts
@@ -1,0 +1,44 @@
+export type ServiceOffer = {
+  title: string;
+  clientProblem: string;
+  businessOutcome: string;
+  capabilities: string[];
+  ctaTarget: string;
+};
+
+export function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+export function sanitizeServices(items: unknown): ServiceOffer[] {
+  if (!Array.isArray(items)) {
+    return [];
+  }
+
+  return items
+    .filter(
+      (item): item is Record<string, unknown> =>
+        typeof item === "object" && item !== null
+    )
+    .map((item) => {
+      const capabilities = Array.isArray(item.capabilities)
+        ? item.capabilities.filter(isNonEmptyString)
+        : [];
+
+      return {
+        title: item.title,
+        clientProblem: item.clientProblem,
+        businessOutcome: item.businessOutcome,
+        capabilities,
+        ctaTarget: item.ctaTarget,
+      };
+    })
+    .filter(
+      (item): item is ServiceOffer =>
+        isNonEmptyString(item.title) &&
+        isNonEmptyString(item.clientProblem) &&
+        isNonEmptyString(item.businessOutcome) &&
+        isNonEmptyString(item.ctaTarget) &&
+        item.capabilities.length >= 2
+    );
+}

--- a/components/sectionServices/sectionServices.module.scss
+++ b/components/sectionServices/sectionServices.module.scss
@@ -1,0 +1,171 @@
+.section {
+  width: 100%;
+  padding: 5rem 1.25rem;
+  background:
+    linear-gradient(160deg, rgba(15, 23, 42, 0.02) 0%, rgba(226, 232, 240, 0.45) 100%),
+    #ffffff;
+}
+
+.container {
+  max-width: 1140px;
+  margin: 0 auto;
+}
+
+.header {
+  max-width: 760px;
+  margin-bottom: 2rem;
+}
+
+.title {
+  margin: 0;
+  color: #0f172a;
+  font-size: clamp(1.95rem, 2.5vw, 2.6rem);
+  letter-spacing: -0.02em;
+}
+
+.subtitle {
+  margin: 0.85rem 0 0;
+  color: #334155;
+  line-height: 1.65;
+  font-size: 1.02rem;
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1rem;
+}
+
+.card {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  padding: 1.1rem;
+  border-radius: 18px;
+  border: 1px solid #d8e2f0;
+  background: #f8fbff;
+  box-shadow: 0 10px 24px rgba(15, 23, 42, 0.07);
+  animation: reveal 0.45s ease both;
+}
+
+.card:nth-child(2) {
+  animation-delay: 0.08s;
+}
+
+.card:nth-child(3) {
+  animation-delay: 0.16s;
+}
+
+.cardTitle {
+  margin: 0;
+  color: #0f172a;
+  font-size: 1.05rem;
+}
+
+.block {
+  border-left: 3px solid #0ea5e9;
+  padding-left: 0.55rem;
+}
+
+.blockLabel {
+  margin: 0;
+  color: #0f172a;
+  font-weight: 700;
+  font-size: 0.86rem;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
+
+.blockText {
+  margin: 0.25rem 0 0;
+  color: #475569;
+  line-height: 1.6;
+  font-size: 0.93rem;
+}
+
+.capabilities {
+  margin: 0;
+  padding-left: 1.1rem;
+  color: #1e293b;
+  display: grid;
+  gap: 0.32rem;
+}
+
+.capabilities li {
+  font-size: 0.9rem;
+}
+
+.cardAction {
+  margin-top: auto;
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  border-radius: 10px;
+  background: #0f172a;
+  color: #ffffff;
+  text-decoration: none;
+  font-weight: 600;
+  padding: 0.62rem 0.9rem;
+  transition: transform 0.16s ease, opacity 0.16s ease;
+}
+
+.cardAction:hover {
+  transform: translateY(-1px);
+  opacity: 0.95;
+}
+
+.cardAction:focus-visible {
+  outline: 2px solid #0ea5e9;
+  outline-offset: 2px;
+}
+
+.fallback {
+  margin-top: 1rem;
+  color: #475569;
+}
+
+@keyframes reveal {
+  from {
+    opacity: 0;
+    transform: translateY(10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@media (max-width: 1024px) {
+  .grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 700px) {
+  .section {
+    padding: 3.5rem 1rem;
+  }
+
+  .grid {
+    grid-template-columns: 1fr;
+  }
+
+  .card {
+    animation-delay: 0s;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .card {
+    animation: none;
+  }
+
+  .cardAction {
+    transition: none;
+  }
+
+  .cardAction:hover {
+    transform: none;
+  }
+}

--- a/components/sectionServices/sectionServices.tsx
+++ b/components/sectionServices/sectionServices.tsx
@@ -1,0 +1,85 @@
+import React from "react";
+import styles from "./sectionServices.module.scss";
+import servicesData from "../../public/data/services.json";
+
+type ServiceOffer = {
+  title: string;
+  clientProblem: string;
+  businessOutcome: string;
+  capabilities: string[];
+  ctaTarget: string;
+};
+
+function sanitizeServices(items: ServiceOffer[]): ServiceOffer[] {
+  return items.filter((item) => {
+    if (!item?.title?.trim()) {
+      return false;
+    }
+    if (!item.clientProblem?.trim() || !item.businessOutcome?.trim()) {
+      return false;
+    }
+    if (!Array.isArray(item.capabilities) || item.capabilities.length < 2) {
+      return false;
+    }
+    return !!item.ctaTarget?.trim();
+  });
+}
+
+export function SectionServices() {
+  const services = sanitizeServices(servicesData as ServiceOffer[]);
+
+  return (
+    <section id="services" className={styles.section} aria-labelledby="services-title">
+      <div className={styles.container}>
+        <header className={styles.header}>
+          <h2 id="services-title" className={styles.title}>
+            Services
+          </h2>
+          <p className={styles.subtitle}>
+            Des offres concrètes pour transformer un besoin métier en solution
+            livrée, exploitable et évolutive.
+          </p>
+        </header>
+
+        <div className={styles.grid}>
+          {services.map((service) => (
+            <article key={service.title} className={styles.card}>
+              <h3 className={styles.cardTitle}>{service.title}</h3>
+
+              <div className={styles.block}>
+                <p className={styles.blockLabel}>Problème adressé</p>
+                <p className={styles.blockText}>{service.clientProblem}</p>
+              </div>
+
+              <div className={styles.block}>
+                <p className={styles.blockLabel}>Bénéfice métier</p>
+                <p className={styles.blockText}>{service.businessOutcome}</p>
+              </div>
+
+              <ul className={styles.capabilities}>
+                {service.capabilities.map((capability) => (
+                  <li key={`${service.title}-${capability}`}>{capability}</li>
+                ))}
+              </ul>
+
+              <a
+                href={service.ctaTarget}
+                className={styles.cardAction}
+                aria-label={`Me contacter pour ${service.title}`}
+              >
+                Discuter de ce service
+              </a>
+            </article>
+          ))}
+        </div>
+
+        {services.length === 0 ? (
+          <p className={styles.fallback}>
+            Les services sont temporairement indisponibles. Vous pouvez me
+            contacter directement via la section contact.
+          </p>
+        ) : null}
+      </div>
+    </section>
+  );
+}

--- a/components/sectionServices/sectionServices.tsx
+++ b/components/sectionServices/sectionServices.tsx
@@ -1,32 +1,10 @@
 import React from "react";
 import styles from "./sectionServices.module.scss";
 import servicesData from "../../public/data/services.json";
-
-type ServiceOffer = {
-  title: string;
-  clientProblem: string;
-  businessOutcome: string;
-  capabilities: string[];
-  ctaTarget: string;
-};
-
-function sanitizeServices(items: ServiceOffer[]): ServiceOffer[] {
-  return items.filter((item) => {
-    if (!item?.title?.trim()) {
-      return false;
-    }
-    if (!item.clientProblem?.trim() || !item.businessOutcome?.trim()) {
-      return false;
-    }
-    if (!Array.isArray(item.capabilities) || item.capabilities.length < 2) {
-      return false;
-    }
-    return !!item.ctaTarget?.trim();
-  });
-}
+import { sanitizeServices } from "./sectionServices.extensions";
 
 export function SectionServices() {
-  const services = sanitizeServices(servicesData as ServiceOffer[]);
+  const services = sanitizeServices(servicesData);
 
   return (
     <section id="services" className={styles.section} aria-labelledby="services-title">

--- a/components/sectionServices/sectionServices.tsx
+++ b/components/sectionServices/sectionServices.tsx
@@ -42,8 +42,8 @@ export function SectionServices() {
         </header>
 
         <div className={styles.grid}>
-          {services.map((service) => (
-            <article key={service.title} className={styles.card}>
+          {services.map((service, serviceIndex) => (
+            <article key={`${service.title}-${serviceIndex}`} className={styles.card}>
               <h3 className={styles.cardTitle}>{service.title}</h3>
 
               <div className={styles.block}>
@@ -57,8 +57,8 @@ export function SectionServices() {
               </div>
 
               <ul className={styles.capabilities}>
-                {service.capabilities.map((capability) => (
-                  <li key={`${service.title}-${capability}`}>{capability}</li>
+                {service.capabilities.map((capability, capabilityIndex) => (
+                  <li key={`${service.title}-${capability}-${capabilityIndex}`}>{capability}</li>
                 ))}
               </ul>
 

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -8,6 +8,7 @@ import { Hr } from "../components/hr";
 import { HeroSection } from "../components/heroSection";
 import { SectionContact } from "../components/sectionContact";
 import { SectionResume } from "../components/sectionResume";
+import { SectionServices } from "../components/sectionServices";
 import { SectionSkills } from "../components/sectionSkills";
 import { SectionWorkExperiences } from "../components/sectionWorkExperiences";
 import { SectionEducations } from "../components/sectionEducations";
@@ -24,6 +25,8 @@ export default function Home() {
         <div className={styles.container}>
           <div className={styles.main}>
             <SectionResume />
+            <Hr />
+            <SectionServices />
             <Hr />
             <SectionSkills />
             <Hr />

--- a/public/data/services.json
+++ b/public/data/services.json
@@ -1,0 +1,35 @@
+[
+  {
+    "title": "Conception et cadrage de solution",
+    "clientProblem": "Vous avez une idée claire du besoin métier, mais la trajectoire technique manque de structure pour lancer le projet sereinement.",
+    "businessOutcome": "Vous obtenez une feuille de route priorisée, des choix techniques justifiés et un plan de livraison réaliste.",
+    "capabilities": [
+      "Ateliers de cadrage",
+      "Choix d'architecture .NET",
+      "Découpage en lots livrables"
+    ],
+    "ctaTarget": "#contact"
+  },
+  {
+    "title": "Développement Fullstack .NET",
+    "clientProblem": "Votre produit doit évoluer vite sans sacrifier la qualité du code ni la maintenabilité de la solution.",
+    "businessOutcome": "Vous accélérez la mise en production avec une implémentation robuste, testable et alignée sur les usages terrain.",
+    "capabilities": [
+      "API et back-end .NET",
+      "Interfaces web Blazor",
+      "Qualité et performance applicative"
+    ],
+    "ctaTarget": "#contact"
+  },
+  {
+    "title": "Optimisation et intégration IA pragmatique",
+    "clientProblem": "Vos équipes perdent du temps sur des tâches répétitives et cherchent des gains rapides sans complexité excessive.",
+    "businessOutcome": "Vous améliorez l'efficacité opérationnelle grâce à des automatisations utiles et une intégration IA adaptée au contexte.",
+    "capabilities": [
+      "Audit de workflows",
+      "Automatisation ciblée",
+      "Accompagnement à l'adoption"
+    ],
+    "ctaTarget": "#contact"
+  }
+]


### PR DESCRIPTION
Closes #4

## Summary
Implements the Services Section as feature 3/12 to present freelance offers in a clear, business-oriented format.

## Changes
- Added new `SectionServices` component with semantic, accessible card-based layout
- Added static content source `public/data/services.json` for service offers
- Added defensive filtering so invalid service items do not block rendering of valid items
- Added one-page navigation anchor `#services` in header menu
- Integrated Services Section on homepage between About and Skills
- Added responsive SCSS (desktop 3 columns, tablet 2 columns, mobile 1 column) with reduced-motion support

## Acceptance Criteria
- [x] Services are displayed in a structured and scannable format
- [x] Each service explains client problem and business outcome
- [x] Section reflects Fullstack .NET and pragmatic AI positioning
- [x] Section includes clear path to contact via service-level CTA
- [x] Services section is integrated between About and Skills
- [x] Build passes without TypeScript errors