### PR TITLE
feat: Skills Section implementation (issue #5)

### DIFF
--- a/components/sectionSkills/sectionSkills.extensions.ts
+++ b/components/sectionSkills/sectionSkills.extensions.ts
@@ -1,0 +1,164 @@
+export type SkillItem = {
+  label: string;
+  description: string | null;
+  position: number;
+};
+
+export type SkillCategory = {
+  id: string;
+  label: string;
+  supportText: string;
+  sourceCategories: string[];
+  skills: SkillItem[];
+};
+
+export type SkillsLocale = "fr" | "en";
+
+export type SkillsSectionMetadata = {
+  title: string;
+  subtitle: string;
+  fallback: string;
+};
+
+type RawSkill = {
+  label?: unknown;
+  description?: unknown;
+  category?: unknown;
+  position?: unknown;
+};
+
+const CATEGORY_ORDER: Array<{
+  id: string;
+  label: string;
+  supportText: string;
+  sourceCategories: string[];
+}> = [
+  {
+    id: "fullstack-dotnet",
+    label: "Fullstack .NET",
+    supportText: "Le socle principal pour concevoir, livrer et faire évoluer des applications robustes.",
+    sourceCategories: ["Technology", "Technlology"],
+  },
+  {
+    id: "frontend-architecture",
+    label: "Front-end & Architecture",
+    supportText: "Interfaces web, structuration technique et choix d'architecture orientés usage.",
+    sourceCategories: ["other"],
+  },
+  {
+    id: "data-cloud",
+    label: "Data & Cloud",
+    supportText: "Persistance, services cloud et outils pour des solutions prêtes à l'exploitation.",
+    sourceCategories: ["database"],
+  },
+  {
+    id: "delivery-tooling",
+    label: "Delivery & Outils",
+    supportText: "Environnement de production, collaboration d'équipe et suivi du delivery.",
+    sourceCategories: ["software"],
+  },
+  {
+    id: "environment-collaboration",
+    label: "Environnements & Qualités humaines",
+    supportText: "Capacité à intervenir dans des contextes variés avec autonomie et esprit d'équipe.",
+    sourceCategories: ["operatingsystem", "qualification"],
+  },
+];
+
+const SECTION_METADATA: Record<SkillsLocale, SkillsSectionMetadata> = {
+  fr: {
+    title: "Compétences",
+    subtitle:
+      "Une expertise Fullstack .NET complétée par des compétences front-end, cloud, data et delivery pour des projets concrets.",
+    fallback: "Les compétences sont en cours de mise à jour.",
+  },
+  en: {
+    title: "Skills",
+    subtitle:
+      "Fullstack .NET expertise supported by front-end, cloud, data, and delivery capabilities for concrete projects.",
+    fallback: "Skills are currently being updated.",
+  },
+};
+
+export function resolveSkillsSectionMetadata(locale: SkillsLocale): SkillsSectionMetadata {
+  return SECTION_METADATA[locale] || SECTION_METADATA.fr;
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+function toSkillItem(item: RawSkill): SkillItem | null {
+  if (!isNonEmptyString(item.label)) {
+    return null;
+  }
+
+  return {
+    label: item.label,
+    description: isNonEmptyString(item.description) ? item.description : null,
+    position: typeof item.position === "number" ? item.position : Number.MAX_SAFE_INTEGER,
+  };
+}
+
+export function normalizeSkills(items: unknown): SkillCategory[] {
+  if (!Array.isArray(items)) {
+    return [];
+  }
+
+  const grouped = new Map<string, SkillItem[]>();
+
+  CATEGORY_ORDER.forEach((category) => {
+    grouped.set(category.id, []);
+  });
+
+  items.forEach((item) => {
+    if (typeof item !== "object" || item === null) {
+      return;
+    }
+
+    const rawSkill = item as RawSkill;
+    const sourceCategory = isNonEmptyString(rawSkill.category)
+      ? rawSkill.category.trim().toLowerCase()
+      : null;
+    if (!sourceCategory) {
+      return;
+    }
+
+    const targetCategory = CATEGORY_ORDER.find((category) =>
+      category.sourceCategories.some((cat) => cat.toLowerCase() === sourceCategory)
+    );
+    if (!targetCategory) {
+      return;
+    }
+
+    const normalizedSkill = toSkillItem(rawSkill);
+    if (!normalizedSkill) {
+      return;
+    }
+
+    const categorySkills = grouped.get(targetCategory.id);
+    if (!categorySkills) {
+      return;
+    }
+
+    const alreadyExists = categorySkills.some(
+      (skill) => skill.label.toLowerCase() === normalizedSkill.label.toLowerCase()
+    );
+    if (alreadyExists) {
+      return;
+    }
+
+    categorySkills.push(normalizedSkill);
+  });
+
+  return CATEGORY_ORDER.map((category) => ({
+    ...category,
+    skills: (grouped.get(category.id) || []).sort((left, right) => {
+      if (left.position !== right.position) {
+        return left.position - right.position;
+      }
+
+      return left.label.localeCompare(right.label, "fr");
+    }),
+  })).filter((category) => category.skills.length > 0);
+}

--- a/components/sectionSkills/sectionSkills.module.scss
+++ b/components/sectionSkills/sectionSkills.module.scss
@@ -5,6 +5,7 @@
           radial-gradient(circle at 10% 12%, rgba(14, 165, 233, 0.10), transparent 34%),
           radial-gradient(circle at 88% 82%, rgba(15, 23, 42, 0.08), transparent 30%),
           #f8fbfc;
+}
 
 .container {
 	max-width: 1140px;
@@ -45,6 +46,7 @@
   border: 1px solid #dbe4f3;
   background: #ffffff;
   box-shadow: 0 10px 24px rgba(15, 23, 42, 0.06);
+}
 
 .cardTitle {
 	margin: 0;
@@ -72,6 +74,7 @@
   background: #f8fbff;
   border: 1px solid #e0e8f6;
   padding: 0.6rem 0.65rem;
+}
 
 .skillLabel {
 	margin: 0;
@@ -85,6 +88,7 @@
   color: #475569;
   line-height: 1.5;
   font-size: 0.84rem;
+}
 
 .fallback {
 	margin-top: 1rem;

--- a/components/sectionSkills/sectionSkills.module.scss
+++ b/components/sectionSkills/sectionSkills.module.scss
@@ -1,0 +1,111 @@
+.section {
+	width: 100%;
+	padding: 5rem 1.25rem;
+	background:
+		radial-gradient(circle at 20% 20%, rgba(15, 23, 42, 0.03) 0%, transparent 45%),
+		linear-gradient(180deg, #ffffff 0%, #f8fafc 100%);
+}
+
+.container {
+	max-width: 1140px;
+	margin: 0 auto;
+}
+
+.header {
+	max-width: 760px;
+	margin-bottom: 2rem;
+}
+
+.title {
+	margin: 0;
+	color: #0f172a;
+	font-size: clamp(1.95rem, 2.5vw, 2.6rem);
+	letter-spacing: -0.02em;
+}
+
+.subtitle {
+	margin: 0.85rem 0 0;
+	color: #334155;
+	line-height: 1.65;
+	font-size: 1.02rem;
+}
+
+.grid {
+	display: grid;
+	grid-template-columns: repeat(3, minmax(0, 1fr));
+	gap: 1rem;
+}
+
+.card {
+	display: flex;
+	flex-direction: column;
+	gap: 0.8rem;
+	padding: 1.1rem;
+	border-radius: 16px;
+	border: 1px solid #dbe4f3;
+	background: #ffffff;
+	box-shadow: 0 10px 24px rgba(15, 23, 42, 0.06);
+}
+
+.cardTitle {
+	margin: 0;
+	color: #0f172a;
+	font-size: 1.05rem;
+}
+
+.cardSupport {
+	margin: 0;
+	color: #475569;
+	line-height: 1.6;
+	font-size: 0.92rem;
+}
+
+.skillsList {
+	margin: 0;
+	padding: 0;
+	list-style: none;
+	display: grid;
+	gap: 0.45rem;
+}
+
+.skillItem {
+	border-radius: 10px;
+	background: #f8fbff;
+	border: 1px solid #e0e8f6;
+	padding: 0.6rem 0.65rem;
+}
+
+.skillLabel {
+	margin: 0;
+	color: #14213d;
+	font-weight: 600;
+	font-size: 0.9rem;
+}
+
+.skillDescription {
+	margin: 0.32rem 0 0;
+	color: #475569;
+	line-height: 1.5;
+	font-size: 0.84rem;
+}
+
+.fallback {
+	margin-top: 1rem;
+	color: #475569;
+}
+
+@media (max-width: 1024px) {
+	.grid {
+		grid-template-columns: repeat(2, minmax(0, 1fr));
+	}
+}
+
+@media (max-width: 700px) {
+	.section {
+		padding: 3.5rem 1rem;
+	}
+
+	.grid {
+		grid-template-columns: 1fr;
+	}
+}

--- a/components/sectionSkills/sectionSkills.tsx
+++ b/components/sectionSkills/sectionSkills.tsx
@@ -1,353 +1,49 @@
-// Libs
-import React from 'react';
-
-// Images
-
-// CSS Module
-import styles from "./sectionSkills.module.scss"
-
-// Data
+import React from "react";
+import styles from "./sectionSkills.module.scss";
 import skillsData from "../../public/data/skills.json";
-import { json } from 'stream/consumers';
+import {
+  normalizeSkills,
+  resolveSkillsSectionMetadata,
+  SkillsLocale,
+} from "./sectionSkills.extensions";
 
-export function SectionSkills () {
-  interface Skill {
-    label: string;
-    description: string;
-    category: SkillCategory;
-    position: number;
-  }
-
-  enum SkillCategory {
-    Technlology = "Technologie Microsoft",
-    Database = "Base de donnée",
-    Other = "Autre",
-    Software = "Logiciel",
-    OperatingSystem = "Système d'exploitation",
-    Qualification = "Compétence"
-  }
-
-//   const skills: Array<Skill> = JSON.parse(skillsData); // converrt to skill
-  const skills = skillsData;
-  const categories = Object.values(SkillCategory);
+export function SectionSkills() {
+  const locale: SkillsLocale = "fr";
+  const metadata = resolveSkillsSectionMetadata(locale);
+  const categories = normalizeSkills(skillsData);
 
   return (
-    <section id="skills" className="content-section text-center">
-        <div className='skills-section'>
-            <div className='skills-container'>
-                <h2>Skills</h2>
-                <div className="row pr-2">
-                          
-                    {categories.map((value, index) => {
-                    return (
-                        <div key={index} className="col-md-4 col-sm-6 col-xs-12">
-                            <div className="bloc-title-skills">
-                                <div className="title-skills"><span className="label label-primary">{value}</span></div>
-                            </div>
-                            {skillsData.filter((item) => item.category == value).map((skill, indexSkill) => {
-                            return (      
-                                <div key={indexSkill}>                
-                                    <span className="label-progress">{skill.label}</span>
-                                    <div className="progress">
-                                        <div className="progress-bar progress-bar-striped active" role="progressbar" style={{width:'90%'}}>
-                                            90%
-                                            <span className="sr-only">90% Complete</span>
-                                        </div>
-                                    </div> 
-                                    {/* <div className="progress">
-                                        <div className="progress-bar progress-bar-striped active" role="progressbar" aria-valuenow="90" aria-valuemin="0" aria-valuemax="100">
-                                            90%
-                                            <span className="sr-only">90% Complete</span>
-                                        </div>
-                                    </div> */}
-                                </div>          
-                            )})}
-                        </div>
-                    )})}
-                </div>
-            </div>
+    <section id="skills" className={styles.section} aria-labelledby="skills-title">
+      <div className={styles.container}>
+        <header className={styles.header}>
+          <h2 id="skills-title" className={styles.title}>
+            {metadata.title}
+          </h2>
+          <p className={styles.subtitle}>{metadata.subtitle}</p>
+        </header>
+
+        <div className={styles.grid}>
+          {categories.map((category) => (
+            <article key={category.id} className={styles.card}>
+              <h3 className={styles.cardTitle}>{category.label}</h3>
+              <p className={styles.cardSupport}>{category.supportText}</p>
+
+              <ul className={styles.skillsList}>
+                {category.skills.map((skill) => (
+                  <li key={`${category.id}-${skill.label}`} className={styles.skillItem}>
+                    <p className={styles.skillLabel}>{skill.label}</p>
+                    {skill.description ? (
+                      <p className={styles.skillDescription}>{skill.description}</p>
+                    ) : null}
+                  </li>
+                ))}
+              </ul>
+            </article>
+          ))}
         </div>
-        {/* <div className="skills-section">
-            <div className="skills-container">
-                <h2>Skills</h2>
-                <div className="row pr-2">
-                    <div className="col-md-4 col-sm-6 col-xs-12">
-                        <div className="bloc-title-skills">
-                            <div className="title-skills"><span className="label label-primary">Technology</span></div>
-                        </div>
-                        <span className="label-progress">Microsoft .NET</span>
-                        <div className="progress">
-                            <div className="progress-bar progress-bar-striped active" role="progressbar" aria-valuenow="90" aria-valuemin="0" aria-valuemax="100" style="width: 90%">
-                                90%
-                                <span className="sr-only">90% Complete</span>
-                            </div>
-                        </div>
-                        <span className="label-progress">AJAX</span>
-                        <div className="progress">
-                            <div className="progress-bar progress-bar-striped active" role="progressbar" aria-valuenow="90" aria-valuemin="0" aria-valuemax="100" style="width: 90%">
-                                90%
-                                <span className="sr-only">90% Complete</span>
-                            </div>
-                        </div>
-                        <span className="label-progress">SSIS</span>
-                        <div className="progress">
-                            <div className="progress-bar progress-bar-striped active" role="progressbar" aria-valuenow="90" aria-valuemin="0" aria-valuemax="100" style="width: 90%">
-                                70%
-                                <span className="sr-only">90% Complete</span>
-                            </div>
-                        </div>
-                        <div className="bloc-title-skills">
-                            <div className="title-skills"><span className="label label-primary">language</span></div>
-                        </div>
-                        <span className="label-progress">HTML5</span>
-                        <div className="progress">
-                            <div className="progress-bar progress-bar-striped active" role="progressbar" aria-valuenow="95" aria-valuemin="0" aria-valuemax="100" style="width: 95%">
-                                95%
-                                <span className="sr-only">95% Complete</span>
-                            </div>
-                        </div>
-                        <span className="label-progress">CSS3</span>
-                        <div className="progress">
-                            <div className="progress-bar progress-bar-striped active" role="progressbar" aria-valuenow="95" aria-valuemin="0" aria-valuemax="100" style="width: 95%">
-                                95%
-                                <span className="sr-only">95% Complete</span>
-                            </div>
-                        </div>
-                        <span className="label-progress">JavaScript</span>
-                        <div className="progress">
-                            <div className="progress-bar progress-bar-striped active" role="progressbar" aria-valuenow="85" aria-valuemin="0" aria-valuemax="100" style="width: 85%">
-                                85%
-                                <span className="sr-only">85% Complete</span>
-                            </div>
-                        </div>
-                        <span className="label-progress">PHP</span>
-                        <div className="progress">
-                            <div className="progress-bar progress-bar-striped active" role="progressbar" aria-valuenow="60" aria-valuemin="0" aria-valuemax="100" style="width: 60%">
-                                60%
-                                <span className="sr-only">60% Complete</span>
-                            </div>
-                        </div>
-                        <span className="label-progress">ASP.NET</span>
-                        <div className="progress">
-                            <div className="progress-bar progress-bar-striped active" role="progressbar" aria-valuenow="90" aria-valuemin="0" aria-valuemax="100" style="width: 90%">
-                                90%
-                                <span className="sr-only">90% Complete</span>
-                            </div>
-                        </div>
-                        <span className="label-progress">SQL</span>
-                        <div className="progress">
-                            <div className="progress-bar progress-bar-striped active" role="progressbar" aria-valuenow="95" aria-valuemin="0" aria-valuemax="100" style="width: 95%">
-                                95%
-                                <span className="sr-only">95% Complete</span>
-                            </div>
-                        </div>
-                        <span className="label-progress">C#</span>
-                        <div className="progress">
-                            <div className="progress-bar progress-bar-striped active" role="progressbar" aria-valuenow="90" aria-valuemin="0" aria-valuemax="100" style="width: 90%">
-                                90%
-                                <span className="sr-only">90% Complete</span>
-                            </div>
-                        </div>
-                        <span className="label-progress">Java</span>
-                        <div className="progress">
-                            <div className="progress-bar progress-bar-striped active" role="progressbar" aria-valuenow="50" aria-valuemin="0" aria-valuemax="100" style="width: 50%">
-                                50%
-                                <span className="sr-only">50% Complete</span>
-                            </div>
-                        </div>
-                        <span className="label-progress">XML</span>
-                        <div className="progress">
-                            <div className="progress-bar progress-bar-striped active" role="progressbar" aria-valuenow="95" aria-valuemin="0" aria-valuemax="100" style="width: 95%">
-                                95%
-                                <span className="sr-only">95% Complete</span>
-                            </div>
-                        </div>
-                        <span className="label-progress">JSON</span>
-                        <div className="progress">
-                            <div className="progress-bar progress-bar-striped active" role="progressbar" aria-valuenow="95" aria-valuemin="0" aria-valuemax="100" style="width: 95%">
-                                95%
-                                <span className="sr-only">95% Complete</span>
-                            </div>
-                        </div>
-    
-                    </div>
-                    <div className="col-md-4 col-sm-6 col-xs-12">
-                        <div className="bloc-title-skills">
-                            <div className="title-skills"><span className="label label-info">Operating systems</span></div>
-                        </div>
-                        <span className="label-progress">Windows XP, Vista, 7, 8, 10</span>
-                        <div className="progress">
-                            <div className="progress-bar progress-bar-info progress-bar-striped active" role="progressbar" aria-valuenow="90" aria-valuemin="0" aria-valuemax="100" style="width: 90%">
-                                90%
-                                <span className="sr-only">90% Complete</span>
-                            </div>
-                        </div>
-                        <span className="label-progress">Mac OS X</span>
-                        <div className="progress">
-                            <div className="progress-bar progress-bar-info progress-bar-striped active" role="progressbar" aria-valuenow="75" aria-valuemin="0" aria-valuemax="100" style="width: 75%">
-                                75%
-                                <span className="sr-only">75% Complete</span>
-                            </div>
-                        </div>
-                        <span className="label-progress">Linux</span>
-                        <div className="progress">
-                            <div className="progress-bar progress-bar-info progress-bar-striped active" role="progressbar" aria-valuenow="50" aria-valuemin="0" aria-valuemax="100" style="width: 50%">
-                                50%
-                                <span className="sr-only">50% Complete</span>
-                            </div>
-                        </div>
-                        <div className="bloc-title-skills">
-                            <div className="title-skills"><span className="label label-danger">Database</span></div>
-                        </div>
-                        <span className="label-progress">SQL server</span>
-                        <div className="progress">
-                            <div className="progress-bar progress-bar-danger progress-bar-striped active" role="progressbar" aria-valuenow="90" aria-valuemin="0" aria-valuemax="100" style="width: 90%">
-                                90%
-                                <span className="sr-only">90% Complete</span>
-                            </div>
-                        </div>
-                        <span className="label-progress">Oracle</span>
-                        <div className="progress">
-                            <div className="progress-bar progress-bar-danger progress-bar-striped active" role="progressbar" aria-valuenow="70" aria-valuemin="0" aria-valuemax="100" style="width: 70%">
-                                70%
-                                <span className="sr-only">70% Complete (warning)</span>
-                            </div>
-                        </div>
-                        <span className="label-progress">MySQL</span>
-                        <div className="progress">
-                            <div className="progress-bar progress-bar-danger progress-bar-striped active" role="progressbar" aria-valuenow="80" aria-valuemin="0" aria-valuemax="100" style="width: 80%">
-                                80%
-                                <span className="sr-only">80% Complete</span>
-                            </div>
-                        </div>
-                        <div className="bloc-title-skills">
-                            <div className="title-skills"><span className="label label-warning">IDE &amp; Text Editor</span></div>
-                        </div>
-                        <span className="label-progress">VS 2010, 2012, 2013</span>
-                        <div className="progress">
-                            <div className="progress-bar progress-bar-warning progress-bar-striped active" role="progressbar" aria-valuenow="90" aria-valuemin="0" aria-valuemax="100" style="width: 90%">
-                                90%
-                                <span className="sr-only">90% Complete</span>
-                            </div>
-                        </div>
-                        <span className="label-progress">Adobe Dreamweaver</span>
-                        <div className="progress">
-                            <div className="progress-bar progress-bar-warning progress-bar-striped active" role="progressbar" aria-valuenow="70" aria-valuemin="0" aria-valuemax="100" style="width: 70%">
-                                70%
-                                <span className="sr-only">70% Complete</span>
-                            </div>
-                        </div>
-                        <span className="label-progress">PhpStorm</span>
-                        <div className="progress">
-                            <div className="progress-bar progress-bar-warning progress-bar-striped active" role="progressbar" aria-valuenow="60" aria-valuemin="0" aria-valuemax="100" style="width: 60%">
-                                60%
-                                <span className="sr-only">60% Complete</span>
-                            </div>
-                        </div>
-                        <span className="label-progress">Eclipse</span>
-                        <div className="progress">
-                            <div className="progress-bar progress-bar-warning progress-bar-striped active" role="progressbar" aria-valuenow="60" aria-valuemin="0" aria-valuemax="100" style="width: 60%">
-                                60%
-                                <span className="sr-only">60% Complete</span>
-                            </div>
-                        </div>
-                        <span className="label-progress">Sublime Text 2</span>
-                        <div className="progress">
-                            <div className="progress-bar progress-bar-warning progress-bar-striped active" role="progressbar" aria-valuenow="85" aria-valuemin="0" aria-valuemax="100" style="width: 85%">
-                                85%
-                                <span className="sr-only">85% Complete</span>
-                            </div>
-                        </div>
-                        <span className="label-progress">Notepad ++</span>
-                        <div className="progress">
-                            <div className="progress-bar progress-bar-warning progress-bar-striped active" role="progressbar" aria-valuenow="90" aria-valuemin="0" aria-valuemax="100" style="width: 90%">
-                                90%
-                                <span className="sr-only">90% Complete</span>
-                            </div>
-                        </div>
-                    <div className="col-md-4 col-sm-6 col-xs-12">
-                        <!-- Bloc Office software -->
-                        <div className="bloc-title-skills">
-                            <div className="title-skills"><span className="label label-success">Office software</span></div>
-                        </div>
-                        <span className="label-progress">Team Foundation Server (TFS)</span>
-                        <div className="progress">
-                            <div className="progress-bar progress-bar-success progress-bar-striped active" role="progressbar" aria-valuenow="85" aria-valuemin="0" aria-valuemax="100" style="width: 85%">
-                                85%
-                                <span className="sr-only">85% Complete</span>
-                            </div>
-                        </div>
-                        <span className="label-progress">Microsoft Office</span>
-                        <div className="progress">
-                            <div className="progress-bar progress-bar-success progress-bar-striped active" role="progressbar" aria-valuenow="90" aria-valuemin="0" aria-valuemax="100" style="width: 90%">
-                                90%
-                                <span className="sr-only">90% Complete</span>
-                            </div>
-                        </div>
-                        <span className="label-progress">iWorks (Mac)</span>
-                        <div className="progress">
-                            <div className="progress-bar progress-bar-success progress-bar-striped active" role="progressbar" aria-valuenow="90" aria-valuemin="0" aria-valuemax="100" style="width: 90%">
-                                90%
-                                <span className="sr-only">90% Complete</span>
-                            </div>
-                        </div>
-                        <span className="label-progress">Adobe Photoshop</span>
-                        <div className="progress">
-                            <div className="progress-bar progress-bar-success progress-bar-striped active" role="progressbar" aria-valuenow="80" aria-valuemin="0" aria-valuemax="100" style="width: 80%">
-                                80%
-                                <span className="sr-only">80% Complete</span>
-                            </div>
-                        </div>
-                        <span className="label-progress">Adobe InDesign</span>
-                        <div className="progress">
-                            <div className="progress-bar progress-bar-success progress-bar-striped active" role="progressbar" aria-valuenow="70" aria-valuemin="0" aria-valuemax="100" style="width: 70%">
-                                70%
-                                <span className="sr-only">70% Complete</span>
-                            </div>
-                        </div>
-                        <div className="bloc-title-skills">
-                            <div className="title-skills"><span className="label label-grey">qualifications</span></div>
-                        </div>
-                        <span className="label-progress">team spirit</span>
-                        <div className="progress">
-                            <div className="progress-bar progress-bar-grey progress-bar-striped active" role="progressbar" aria-valuenow="95" aria-valuemin="0" aria-valuemax="100" style="width: 95%">
-                                95%
-                                <span className="sr-only">95% Complete</span>
-                            </div>
-                        </div>
-                        <span className="label-progress">self-educated</span>
-                        <div className="progress">
-                            <div className="progress-bar progress-bar-grey progress-bar-striped active" role="progressbar" aria-valuenow="95" aria-valuemin="0" aria-valuemax="100" style="width: 95%">
-                                95%
-                                <span className="sr-only">95% Complete</span>
-                            </div>
-                        </div>
-                        <span className="label-progress">dynamic</span>
-                        <div className="progress">
-                            <div className="progress-bar progress-bar-grey progress-bar-striped active" role="progressbar" aria-valuenow="95" aria-valuemin="0" aria-valuemax="100" style="width: 95%">
-                                95%
-                                <span className="sr-only">95% Complete</span>
-                            </div>
-                        </div>
-                        <span className="label-progress">methodical</span>
-                        <div className="progress">
-                            <div className="progress-bar progress-bar-grey progress-bar-striped active" role="progressbar" aria-valuenow="95" aria-valuemin="0" aria-valuemax="100" style="width: 95%">
-                                95%
-                                <span className="sr-only">95% Complete</span>
-                            </div>
-                        </div>
-                        <span className="label-progress">autonomous</span>
-                        <div className="progress">
-                            <div className="progress-bar progress-bar-grey progress-bar-striped active" role="progressbar" aria-valuenow="95" aria-valuemin="0" aria-valuemax="100" style="width: 95%">
-                                95%
-                                <span className="sr-only">95% Complete</span>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-    
-            </div>
-        </div> */}
+
+        {categories.length === 0 ? <p className={styles.fallback}>{metadata.fallback}</p> : null}
+      </div>
     </section>
   );
 }


### PR DESCRIPTION
## Summary
Implements the Skills Section for phase 1.

## Implemented
- Replaced legacy skills rendering with structured category cards.
- Added robust normalization logic with canonical categories and deduplication.
- Added locale-ready section metadata (FR/EN fallback structure).
- Added responsive styling (3 columns desktop, 2 tablet, 1 mobile).
- Kept `skills` anchor stable for one-page navigation.

## Validation
- `npm run build` ✅

## Notes
- Includes compatibility for legacy `Technlology` source category key in static data.

Closes #5