### PR TITLE
feat: Contact Section implementation (issue #6)

### DIFF
--- a/components/heroSection/heroSection.tsx
+++ b/components/heroSection/heroSection.tsx
@@ -37,7 +37,7 @@ function HeroActionGroup() {
   return (
     <div className={styles.actionGroup} role="group" aria-label="Actions principales">
       <a
-        href="mailto:contact@valentin-passe.com"
+        href="mailto:passe.valentin@gmail.com"
         className={`${styles.btn} ${styles.btnPrimary}`}
         aria-label="Envoyer un e-mail à Valentin Passe"
       >

--- a/components/heroSection/heroSection.tsx
+++ b/components/heroSection/heroSection.tsx
@@ -44,7 +44,7 @@ function HeroActionGroup() {
         Me contacter
       </a>
       <a
-        href="#sectionProjects"
+        href="#projects"
         className={`${styles.btn} ${styles.btnOutline}`}
         aria-label="Voir les projets de Valentin Passe"
       >

--- a/components/sectionContact/sectionContact.module.scss
+++ b/components/sectionContact/sectionContact.module.scss
@@ -23,6 +23,19 @@
   color: #334155;
 }
 
+.inquiryList {
+  margin: 1.25rem auto 0;
+  max-width: 680px;
+  text-align: left;
+  display: grid;
+  gap: 0.45rem;
+  color: #1f2937;
+}
+
+.inquiryItem {
+  line-height: 1.55;
+}
+
 .actions {
   margin-top: 1.75rem;
   display: flex;
@@ -41,6 +54,7 @@
   text-decoration: none;
   font-weight: 600;
   transition: transform 0.15s ease, opacity 0.15s ease;
+  cursor: pointer;
 }
 
 .primaryAction {
@@ -52,6 +66,29 @@
   background-color: #ffffff;
   color: #0f172a;
   border: 1px solid #cbd5e1;
+}
+
+.emailText {
+  margin: 1rem 0 0;
+  color: #334155;
+}
+
+.emailText a {
+  color: #0f172a;
+  font-weight: 600;
+}
+
+.meta {
+  margin: 0.35rem 0 0;
+  color: #475569;
+  font-size: 0.95rem;
+}
+
+.feedback {
+  min-height: 1.2rem;
+  margin: 0.7rem 0 0;
+  color: #0f766e;
+  font-size: 0.9rem;
 }
 
 .primaryAction:hover,
@@ -75,5 +112,21 @@
   .primaryAction:hover,
   .secondaryAction:hover {
     transform: none;
+  }
+}
+
+@media (max-width: 640px) {
+  .section {
+    padding: 3.5rem 1rem;
+  }
+
+  .actions {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .inquiryList {
+    margin-top: 1rem;
+    padding-left: 1.1rem;
   }
 }

--- a/components/sectionContact/sectionContact.tsx
+++ b/components/sectionContact/sectionContact.tsx
@@ -1,34 +1,77 @@
-import React from "react";
+import React, { useState } from "react";
 import styles from "./sectionContact.module.scss";
 
+const CONTACT_EMAIL = "passe.valentin@gmail.com";
+
+const INQUIRY_TYPES = [
+  "Création ou refonte d'application web .NET",
+  "Renfort Fullstack sur produit existant",
+  "Audit technique et plan de delivery",
+];
+
 export function SectionContact() {
+  const [feedback, setFeedback] = useState<string>("");
+
+  const handleCopyEmail = async () => {
+    if (typeof navigator === "undefined" || !navigator.clipboard) {
+      setFeedback("Copie non disponible. Utilisez l'adresse e-mail affichée ci-dessous.");
+      return;
+    }
+
+    try {
+      await navigator.clipboard.writeText(CONTACT_EMAIL);
+      setFeedback("Adresse e-mail copiée.");
+    } catch {
+      setFeedback("Impossible de copier l'adresse automatiquement. Copiez-la manuellement.");
+    }
+  };
+
   return (
     <section id="contact" className={styles.section} aria-labelledby="contact-title">
       <div className={styles.container}>
-        <h2 id="contact-title" className={styles.title}>Contact</h2>
+        <h2 id="contact-title" className={styles.title}>
+          Contact
+        </h2>
         <p className={styles.description}>
-          Discutons de votre projet. Je suis disponible pour des missions
-          freelance fullstack .NET.
+          Dites-moi ce que vous souhaitez livrer et je vous réponds rapidement.
+          Je suis disponible pour des missions freelance .NET en remote, hybride
+          ou sur site.
         </p>
+
+        <ul className={styles.inquiryList} aria-label="Types de demandes">
+          {INQUIRY_TYPES.map((item) => (
+            <li key={item} className={styles.inquiryItem}>
+              {item}
+            </li>
+          ))}
+        </ul>
 
         <div className={styles.actions}>
           <a
-            href="mailto:contact@valentin-passe.com"
+            href={`mailto:${CONTACT_EMAIL}`}
             className={styles.primaryAction}
             aria-label="Envoyer un e-mail à Valentin Passe"
           >
             Me contacter
           </a>
-          <a
-            href="/images/resume/valentin-passe.webp"
-            target="_blank"
-            rel="noopener noreferrer"
+
+          <button
+            type="button"
             className={styles.secondaryAction}
-            aria-label="Télécharger le CV de Valentin Passe"
+            onClick={handleCopyEmail}
+            aria-label="Copier l'adresse e-mail"
           >
-            Télécharger le CV
-          </a>
+            Copier l'adresse e-mail
+          </button>
         </div>
+
+        <p className={styles.emailText}>
+          Email direct: <a href={`mailto:${CONTACT_EMAIL}`}>{CONTACT_EMAIL}</a>
+        </p>
+        <p className={styles.meta}>Nice, Provence-Alpes-Côte d'Azur · LinkedIn disponible sur demande</p>
+        <p className={styles.feedback} role="status" aria-live="polite">
+          {feedback}
+        </p>
       </div>
     </section>
   );


### PR DESCRIPTION
## Summary
Implements the Contact Section for phase 1 with a direct email path and explicit fallback.

## Implemented
- Updated contact copy focused on project inquiry conversion.
- Switched to approved business email address.
- Added inquiry type guidance (3 key request categories).
- Added primary mailto CTA and copy-to-clipboard fallback action.
- Added explicit readable email text fallback and feedback with `aria-live`.
- Improved responsive behavior for mobile actions.

## Validation
- `npm run build` ✅

Closes #6