### PR TITLE
feat: Experience Section implementation (issue #7)

### DIFF
--- a/components/headerCustom/headerCustom.tsx
+++ b/components/headerCustom/headerCustom.tsx
@@ -30,7 +30,7 @@ export function HeaderCustom () {
     },
     {
       label: 'Expériences professionnelles',
-      route: '#workExperiences',
+      route: '#experience',
     },
     {
       label: 'Formations',

--- a/components/sectionWorkExperiences/sectionWorkExperiences.module.scss
+++ b/components/sectionWorkExperiences/sectionWorkExperiences.module.scss
@@ -1,0 +1,155 @@
+.section {
+	width: 100%;
+	padding: 5rem 1.25rem;
+	background: linear-gradient(180deg, #ffffff 0%, #f7f9fc 100%);
+}
+
+.container {
+	max-width: 1140px;
+	margin: 0 auto;
+}
+
+.header {
+	max-width: 760px;
+	margin-bottom: 2rem;
+}
+
+.title {
+	margin: 0;
+	color: #0f172a;
+	font-size: clamp(1.95rem, 2.5vw, 2.6rem);
+	letter-spacing: -0.02em;
+}
+
+.subtitle {
+	margin: 0.85rem 0 0;
+	color: #334155;
+	line-height: 1.65;
+	font-size: 1.02rem;
+}
+
+.timeline {
+	position: relative;
+	display: grid;
+	gap: 1rem;
+}
+
+.timeline::before {
+	content: "";
+	position: absolute;
+	left: 0.62rem;
+	top: 0;
+	bottom: 0;
+	width: 2px;
+	background: linear-gradient(180deg, #0f172a 0%, #64748b 100%);
+}
+
+.card {
+	position: relative;
+	margin-left: 2rem;
+	border: 1px solid #d7e0f1;
+	border-radius: 16px;
+	background: #ffffff;
+	box-shadow: 0 10px 24px rgba(15, 23, 42, 0.06);
+	padding: 1rem 1.05rem;
+}
+
+.card::before {
+	content: "";
+	position: absolute;
+	left: -1.8rem;
+	top: 1.15rem;
+	width: 11px;
+	height: 11px;
+	border-radius: 50%;
+	background: #0f172a;
+}
+
+.period {
+	margin: 0;
+	color: #0f172a;
+	font-weight: 700;
+	font-size: 0.9rem;
+}
+
+.role {
+	margin: 0.3rem 0 0;
+	color: #0f172a;
+	font-size: 1.05rem;
+}
+
+.organization {
+	margin: 0.2rem 0 0.7rem;
+	color: #334155;
+	font-weight: 500;
+}
+
+.blockLabel {
+	margin: 0.6rem 0 0;
+	color: #0f172a;
+	font-weight: 700;
+	font-size: 0.86rem;
+	text-transform: uppercase;
+	letter-spacing: 0.03em;
+}
+
+.blockText {
+	margin: 0.25rem 0 0;
+	color: #475569;
+	line-height: 1.6;
+	font-size: 0.93rem;
+}
+
+.techList {
+	margin: 0.75rem 0 0;
+	padding: 0;
+	list-style: none;
+	display: flex;
+	flex-wrap: wrap;
+	gap: 0.45rem;
+}
+
+.techItem {
+	border-radius: 999px;
+	border: 1px solid #d6dfef;
+	background: #f8fbff;
+	color: #1e293b;
+	padding: 0.25rem 0.6rem;
+	font-size: 0.82rem;
+}
+
+.educationCta {
+	margin-top: 1.2rem;
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	border-radius: 10px;
+	background: #0f172a;
+	color: #ffffff;
+	text-decoration: none;
+	font-weight: 600;
+	padding: 0.65rem 0.95rem;
+}
+
+.educationCta:hover,
+.educationCta:focus-visible {
+	opacity: 0.95;
+}
+
+@media (max-width: 700px) {
+	.section {
+		padding: 3.5rem 1rem;
+	}
+
+	.timeline::before {
+		display: none;
+	}
+
+	.card {
+		margin-left: 0;
+	}
+
+	.card::before {
+		display: none;
+	}
+}

--- a/components/sectionWorkExperiences/sectionWorkExperiences.tsx
+++ b/components/sectionWorkExperiences/sectionWorkExperiences.tsx
@@ -1,316 +1,105 @@
-// Libs
-import React from 'react';
+import React from "react";
+import styles from "./sectionWorkExperiences.module.scss";
 
-// Images
+type ExperienceEntry = {
+  roleTitle: string;
+  organizationLabel: string;
+  period: string;
+  context: string;
+  valueDelivered: string;
+  tech: string[];
+};
 
-// CSS Module
-import styles from "./sectionWorkExperiences.module.scss"
+const ENTRIES: ExperienceEntry[] = [
+  {
+    roleTitle: "Ingénieur Développement Fullstack .NET",
+    organizationLabel: "SMEG, Monaco",
+    period: "Nov. 2023 - Aujourd'hui",
+    context:
+      "Gestion des appels d'astreinte, d'urgence et interventions pour des usages bureau et mobile.",
+    valueDelivered:
+      "Conception et livraison d'une solution robuste, orientée fiabilité opérationnelle et réactivité terrain.",
+    tech: [".NET 7", "C#", "ABP", "DDD", "Azure", "Docker", "RabbitMQ", "Redis", "MongoDB"],
+  },
+  {
+    roleTitle: "Ingénieur Développement Fullstack .NET",
+    organizationLabel: "Groupe C8G",
+    period: "Juin 2023 - Aujourd'hui",
+    context:
+      "Développement de solutions web métier orientées usages internes et efficacité quotidienne.",
+    valueDelivered:
+      "Mise en production de fonctionnalités fullstack accélérant la livraison et la maintenabilité des produits.",
+    tech: [".NET", "Blazor", "Entity Framework", "Azure", "Vue.js"],
+  },
+  {
+    roleTitle: "Développeur Back-end .NET",
+    organizationLabel: "TidyUp Technologies",
+    period: "Juin 2023 - Oct. 2023",
+    context:
+      "Plateforme de rangement, classement et recherche de contenus numériques avec composante IA.",
+    valueDelivered:
+      "Construction d'un socle backend pérenne pour la recherche de contenus et l'évolution produit.",
+    tech: [".NET MVC", ".NET Core", "C#", "Xamarin Forms", "SQL"],
+  },
+  {
+    roleTitle: "Développeur Back-end .NET",
+    organizationLabel: "UBALDI.com",
+    period: "Avr. 2021 - Juin 2023",
+    context: "Contribution à plusieurs projets internes orientés continuité de service et performance.",
+    valueDelivered:
+      "Fiabilisation du delivery backend et amélioration continue des processus techniques internes.",
+    tech: [".NET", "C#", "API", "SQL Server"],
+  },
+  {
+    roleTitle: "Développeur Fullstack .NET",
+    organizationLabel: "Régie Eau d'Azur",
+    period: "Sept. 2015 - Avr. 2021",
+    context:
+      "Réalisation de solutions applicatives internes sur un cycle long avec contraintes métier variées.",
+    valueDelivered:
+      "Industrialisation progressive des applications et renforcement de la qualité de service utilisateur.",
+    tech: [".NET", "C#", "SQL", "Architecture applicative"],
+  },
+];
 
-// Data
-// import skillsData from "../../public/data/skills.json";
-
-export function SectionWorkExperiences () {
-//   interface Skill {
-//     label: string;
-//     description: string;
-//     category: SkillCategory;
-//     position: number;
-//   }
-
-//   enum SkillCategory {
-//     Technlology = "Technologie Microsoft",
-//     Database = "Base de donnée",
-//     Other = "Autre",
-//     Software = "Logiciel",
-//     OperatingSystem = "Système d'exploitation",
-//     Qualification = "Compétence"
-//   }
-
-//   const skills = skillsData; // converrt to skill
-
+export function SectionWorkExperiences() {
   return (
-    <section id="workExperiences" className="content-section text-center">
-        {/* <div className="skills-section">
-            <div className="skills-container">
-                <h2>Skills</h2>
-                <div className="row pr-2">
-                    <div className="col-md-4 col-sm-6 col-xs-12">
-                        <div className="bloc-title-skills">
-                            <div className="title-skills"><span className="label label-primary">Technology</span></div>
-                        </div>
-                        <span className="label-progress">Microsoft .NET</span>
-                        <div className="progress">
-                            <div className="progress-bar progress-bar-striped active" role="progressbar" aria-valuenow="90" aria-valuemin="0" aria-valuemax="100" style="width: 90%">
-                                90%
-                                <span className="sr-only">90% Complete</span>
-                            </div>
-                        </div>
-                        <span className="label-progress">AJAX</span>
-                        <div className="progress">
-                            <div className="progress-bar progress-bar-striped active" role="progressbar" aria-valuenow="90" aria-valuemin="0" aria-valuemax="100" style="width: 90%">
-                                90%
-                                <span className="sr-only">90% Complete</span>
-                            </div>
-                        </div>
-                        <span className="label-progress">SSIS</span>
-                        <div className="progress">
-                            <div className="progress-bar progress-bar-striped active" role="progressbar" aria-valuenow="90" aria-valuemin="0" aria-valuemax="100" style="width: 90%">
-                                70%
-                                <span className="sr-only">90% Complete</span>
-                            </div>
-                        </div>
-                        <div className="bloc-title-skills">
-                            <div className="title-skills"><span className="label label-primary">language</span></div>
-                        </div>
-                        <span className="label-progress">HTML5</span>
-                        <div className="progress">
-                            <div className="progress-bar progress-bar-striped active" role="progressbar" aria-valuenow="95" aria-valuemin="0" aria-valuemax="100" style="width: 95%">
-                                95%
-                                <span className="sr-only">95% Complete</span>
-                            </div>
-                        </div>
-                        <span className="label-progress">CSS3</span>
-                        <div className="progress">
-                            <div className="progress-bar progress-bar-striped active" role="progressbar" aria-valuenow="95" aria-valuemin="0" aria-valuemax="100" style="width: 95%">
-                                95%
-                                <span className="sr-only">95% Complete</span>
-                            </div>
-                        </div>
-                        <span className="label-progress">JavaScript</span>
-                        <div className="progress">
-                            <div className="progress-bar progress-bar-striped active" role="progressbar" aria-valuenow="85" aria-valuemin="0" aria-valuemax="100" style="width: 85%">
-                                85%
-                                <span className="sr-only">85% Complete</span>
-                            </div>
-                        </div>
-                        <span className="label-progress">PHP</span>
-                        <div className="progress">
-                            <div className="progress-bar progress-bar-striped active" role="progressbar" aria-valuenow="60" aria-valuemin="0" aria-valuemax="100" style="width: 60%">
-                                60%
-                                <span className="sr-only">60% Complete</span>
-                            </div>
-                        </div>
-                        <span className="label-progress">ASP.NET</span>
-                        <div className="progress">
-                            <div className="progress-bar progress-bar-striped active" role="progressbar" aria-valuenow="90" aria-valuemin="0" aria-valuemax="100" style="width: 90%">
-                                90%
-                                <span className="sr-only">90% Complete</span>
-                            </div>
-                        </div>
-                        <span className="label-progress">SQL</span>
-                        <div className="progress">
-                            <div className="progress-bar progress-bar-striped active" role="progressbar" aria-valuenow="95" aria-valuemin="0" aria-valuemax="100" style="width: 95%">
-                                95%
-                                <span className="sr-only">95% Complete</span>
-                            </div>
-                        </div>
-                        <span className="label-progress">C#</span>
-                        <div className="progress">
-                            <div className="progress-bar progress-bar-striped active" role="progressbar" aria-valuenow="90" aria-valuemin="0" aria-valuemax="100" style="width: 90%">
-                                90%
-                                <span className="sr-only">90% Complete</span>
-                            </div>
-                        </div>
-                        <span className="label-progress">Java</span>
-                        <div className="progress">
-                            <div className="progress-bar progress-bar-striped active" role="progressbar" aria-valuenow="50" aria-valuemin="0" aria-valuemax="100" style="width: 50%">
-                                50%
-                                <span className="sr-only">50% Complete</span>
-                            </div>
-                        </div>
-                        <span className="label-progress">XML</span>
-                        <div className="progress">
-                            <div className="progress-bar progress-bar-striped active" role="progressbar" aria-valuenow="95" aria-valuemin="0" aria-valuemax="100" style="width: 95%">
-                                95%
-                                <span className="sr-only">95% Complete</span>
-                            </div>
-                        </div>
-                        <span className="label-progress">JSON</span>
-                        <div className="progress">
-                            <div className="progress-bar progress-bar-striped active" role="progressbar" aria-valuenow="95" aria-valuemin="0" aria-valuemax="100" style="width: 95%">
-                                95%
-                                <span className="sr-only">95% Complete</span>
-                            </div>
-                        </div>
-    
-                    </div>
-                    <div className="col-md-4 col-sm-6 col-xs-12">
-                        <div className="bloc-title-skills">
-                            <div className="title-skills"><span className="label label-info">Operating systems</span></div>
-                        </div>
-                        <span className="label-progress">Windows XP, Vista, 7, 8, 10</span>
-                        <div className="progress">
-                            <div className="progress-bar progress-bar-info progress-bar-striped active" role="progressbar" aria-valuenow="90" aria-valuemin="0" aria-valuemax="100" style="width: 90%">
-                                90%
-                                <span className="sr-only">90% Complete</span>
-                            </div>
-                        </div>
-                        <span className="label-progress">Mac OS X</span>
-                        <div className="progress">
-                            <div className="progress-bar progress-bar-info progress-bar-striped active" role="progressbar" aria-valuenow="75" aria-valuemin="0" aria-valuemax="100" style="width: 75%">
-                                75%
-                                <span className="sr-only">75% Complete</span>
-                            </div>
-                        </div>
-                        <span className="label-progress">Linux</span>
-                        <div className="progress">
-                            <div className="progress-bar progress-bar-info progress-bar-striped active" role="progressbar" aria-valuenow="50" aria-valuemin="0" aria-valuemax="100" style="width: 50%">
-                                50%
-                                <span className="sr-only">50% Complete</span>
-                            </div>
-                        </div>
-                        <div className="bloc-title-skills">
-                            <div className="title-skills"><span className="label label-danger">Database</span></div>
-                        </div>
-                        <span className="label-progress">SQL server</span>
-                        <div className="progress">
-                            <div className="progress-bar progress-bar-danger progress-bar-striped active" role="progressbar" aria-valuenow="90" aria-valuemin="0" aria-valuemax="100" style="width: 90%">
-                                90%
-                                <span className="sr-only">90% Complete</span>
-                            </div>
-                        </div>
-                        <span className="label-progress">Oracle</span>
-                        <div className="progress">
-                            <div className="progress-bar progress-bar-danger progress-bar-striped active" role="progressbar" aria-valuenow="70" aria-valuemin="0" aria-valuemax="100" style="width: 70%">
-                                70%
-                                <span className="sr-only">70% Complete (warning)</span>
-                            </div>
-                        </div>
-                        <span className="label-progress">MySQL</span>
-                        <div className="progress">
-                            <div className="progress-bar progress-bar-danger progress-bar-striped active" role="progressbar" aria-valuenow="80" aria-valuemin="0" aria-valuemax="100" style="width: 80%">
-                                80%
-                                <span className="sr-only">80% Complete</span>
-                            </div>
-                        </div>
-                        <div className="bloc-title-skills">
-                            <div className="title-skills"><span className="label label-warning">IDE &amp; Text Editor</span></div>
-                        </div>
-                        <span className="label-progress">VS 2010, 2012, 2013</span>
-                        <div className="progress">
-                            <div className="progress-bar progress-bar-warning progress-bar-striped active" role="progressbar" aria-valuenow="90" aria-valuemin="0" aria-valuemax="100" style="width: 90%">
-                                90%
-                                <span className="sr-only">90% Complete</span>
-                            </div>
-                        </div>
-                        <span className="label-progress">Adobe Dreamweaver</span>
-                        <div className="progress">
-                            <div className="progress-bar progress-bar-warning progress-bar-striped active" role="progressbar" aria-valuenow="70" aria-valuemin="0" aria-valuemax="100" style="width: 70%">
-                                70%
-                                <span className="sr-only">70% Complete</span>
-                            </div>
-                        </div>
-                        <span className="label-progress">PhpStorm</span>
-                        <div className="progress">
-                            <div className="progress-bar progress-bar-warning progress-bar-striped active" role="progressbar" aria-valuenow="60" aria-valuemin="0" aria-valuemax="100" style="width: 60%">
-                                60%
-                                <span className="sr-only">60% Complete</span>
-                            </div>
-                        </div>
-                        <span className="label-progress">Eclipse</span>
-                        <div className="progress">
-                            <div className="progress-bar progress-bar-warning progress-bar-striped active" role="progressbar" aria-valuenow="60" aria-valuemin="0" aria-valuemax="100" style="width: 60%">
-                                60%
-                                <span className="sr-only">60% Complete</span>
-                            </div>
-                        </div>
-                        <span className="label-progress">Sublime Text 2</span>
-                        <div className="progress">
-                            <div className="progress-bar progress-bar-warning progress-bar-striped active" role="progressbar" aria-valuenow="85" aria-valuemin="0" aria-valuemax="100" style="width: 85%">
-                                85%
-                                <span className="sr-only">85% Complete</span>
-                            </div>
-                        </div>
-                        <span className="label-progress">Notepad ++</span>
-                        <div className="progress">
-                            <div className="progress-bar progress-bar-warning progress-bar-striped active" role="progressbar" aria-valuenow="90" aria-valuemin="0" aria-valuemax="100" style="width: 90%">
-                                90%
-                                <span className="sr-only">90% Complete</span>
-                            </div>
-                        </div>
-                    <div className="col-md-4 col-sm-6 col-xs-12">
-                        <!-- Bloc Office software -->
-                        <div className="bloc-title-skills">
-                            <div className="title-skills"><span className="label label-success">Office software</span></div>
-                        </div>
-                        <span className="label-progress">Team Foundation Server (TFS)</span>
-                        <div className="progress">
-                            <div className="progress-bar progress-bar-success progress-bar-striped active" role="progressbar" aria-valuenow="85" aria-valuemin="0" aria-valuemax="100" style="width: 85%">
-                                85%
-                                <span className="sr-only">85% Complete</span>
-                            </div>
-                        </div>
-                        <span className="label-progress">Microsoft Office</span>
-                        <div className="progress">
-                            <div className="progress-bar progress-bar-success progress-bar-striped active" role="progressbar" aria-valuenow="90" aria-valuemin="0" aria-valuemax="100" style="width: 90%">
-                                90%
-                                <span className="sr-only">90% Complete</span>
-                            </div>
-                        </div>
-                        <span className="label-progress">iWorks (Mac)</span>
-                        <div className="progress">
-                            <div className="progress-bar progress-bar-success progress-bar-striped active" role="progressbar" aria-valuenow="90" aria-valuemin="0" aria-valuemax="100" style="width: 90%">
-                                90%
-                                <span className="sr-only">90% Complete</span>
-                            </div>
-                        </div>
-                        <span className="label-progress">Adobe Photoshop</span>
-                        <div className="progress">
-                            <div className="progress-bar progress-bar-success progress-bar-striped active" role="progressbar" aria-valuenow="80" aria-valuemin="0" aria-valuemax="100" style="width: 80%">
-                                80%
-                                <span className="sr-only">80% Complete</span>
-                            </div>
-                        </div>
-                        <span className="label-progress">Adobe InDesign</span>
-                        <div className="progress">
-                            <div className="progress-bar progress-bar-success progress-bar-striped active" role="progressbar" aria-valuenow="70" aria-valuemin="0" aria-valuemax="100" style="width: 70%">
-                                70%
-                                <span className="sr-only">70% Complete</span>
-                            </div>
-                        </div>
-                        <div className="bloc-title-skills">
-                            <div className="title-skills"><span className="label label-grey">qualifications</span></div>
-                        </div>
-                        <span className="label-progress">team spirit</span>
-                        <div className="progress">
-                            <div className="progress-bar progress-bar-grey progress-bar-striped active" role="progressbar" aria-valuenow="95" aria-valuemin="0" aria-valuemax="100" style="width: 95%">
-                                95%
-                                <span className="sr-only">95% Complete</span>
-                            </div>
-                        </div>
-                        <span className="label-progress">self-educated</span>
-                        <div className="progress">
-                            <div className="progress-bar progress-bar-grey progress-bar-striped active" role="progressbar" aria-valuenow="95" aria-valuemin="0" aria-valuemax="100" style="width: 95%">
-                                95%
-                                <span className="sr-only">95% Complete</span>
-                            </div>
-                        </div>
-                        <span className="label-progress">dynamic</span>
-                        <div className="progress">
-                            <div className="progress-bar progress-bar-grey progress-bar-striped active" role="progressbar" aria-valuenow="95" aria-valuemin="0" aria-valuemax="100" style="width: 95%">
-                                95%
-                                <span className="sr-only">95% Complete</span>
-                            </div>
-                        </div>
-                        <span className="label-progress">methodical</span>
-                        <div className="progress">
-                            <div className="progress-bar progress-bar-grey progress-bar-striped active" role="progressbar" aria-valuenow="95" aria-valuemin="0" aria-valuemax="100" style="width: 95%">
-                                95%
-                                <span className="sr-only">95% Complete</span>
-                            </div>
-                        </div>
-                        <span className="label-progress">autonomous</span>
-                        <div className="progress">
-                            <div className="progress-bar progress-bar-grey progress-bar-striped active" role="progressbar" aria-valuenow="95" aria-valuemin="0" aria-valuemax="100" style="width: 95%">
-                                95%
-                                <span className="sr-only">95% Complete</span>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-    
-            </div>
-        </div> */}
+    <section id="experience" className={styles.section} aria-labelledby="experience-title">
+      <div className={styles.container}>
+        <header className={styles.header}>
+          <h2 id="experience-title" className={styles.title}>
+            Expérience
+          </h2>
+          <p className={styles.subtitle}>
+            Des missions réelles, menées de bout en bout, avec un focus constant sur la valeur livrée.
+          </p>
+        </header>
+
+        <div className={styles.timeline}>
+          {ENTRIES.map((entry) => (
+            <article key={`${entry.roleTitle}-${entry.organizationLabel}-${entry.period}`} className={styles.card}>
+              <p className={styles.period}>{entry.period}</p>
+              <h3 className={styles.role}>{entry.roleTitle}</h3>
+              <p className={styles.organization}>{entry.organizationLabel}</p>
+              <p className={styles.blockLabel}>Contexte</p>
+              <p className={styles.blockText}>{entry.context}</p>
+              <p className={styles.blockLabel}>Valeur livrée</p>
+              <p className={styles.blockText}>{entry.valueDelivered}</p>
+              <ul className={styles.techList} aria-label="Technologies">
+                {entry.tech.map((item) => (
+                  <li key={`${entry.organizationLabel}-${item}`} className={styles.techItem}>
+                    {item}
+                  </li>
+                ))}
+              </ul>
+            </article>
+          ))}
+        </div>
+
+        <a href="#educations" className={styles.educationCta}>
+          Voir le parcours de formation
+        </a>
+      </div>
     </section>
   );
 }


### PR DESCRIPTION
## Summary
Implements the Experience Section for phase 1 with timeline-style cards and delivery-focused content.

## Implemented
- Replaced placeholder `SectionWorkExperiences` with production-ready section.
- Added 5 structured experience entries (role, organization, period, context, delivered value, technologies).
- Added accessible timeline/card composition with semantic headings and readable date ranges.
- Added bridge CTA to education section (`#educations`).
- Added responsive timeline styles for desktop/tablet/mobile.

## Validation
- `npm run build` ✅

Closes #7