### PR TITLE
feat: Projects Section implementation (issue #8)

### DIFF
--- a/components/sectionProjects/sectionProjects.module.scss
+++ b/components/sectionProjects/sectionProjects.module.scss
@@ -1,0 +1,150 @@
+.section {
+	width: 100%;
+	padding: 5rem 1.25rem;
+	background:
+		linear-gradient(180deg, #f8fafc 0%, #ffffff 100%),
+		radial-gradient(circle at 80% 10%, rgba(14, 165, 233, 0.06) 0%, transparent 42%);
+}
+
+.container {
+	max-width: 1140px;
+	margin: 0 auto;
+}
+
+.header {
+	max-width: 760px;
+	margin-bottom: 2rem;
+}
+
+.title {
+	margin: 0;
+	color: #0f172a;
+	font-size: clamp(1.95rem, 2.5vw, 2.6rem);
+	letter-spacing: -0.02em;
+}
+
+.subtitle {
+	margin: 0.85rem 0 0;
+	color: #334155;
+	line-height: 1.65;
+	font-size: 1.02rem;
+}
+
+.grid {
+	display: grid;
+	grid-template-columns: repeat(3, minmax(0, 1fr));
+	gap: 1rem;
+}
+
+.card {
+	display: flex;
+	flex-direction: column;
+	gap: 0.55rem;
+	border: 1px solid #dbe3f1;
+	border-radius: 16px;
+	background: #ffffff;
+	box-shadow: 0 10px 24px rgba(15, 23, 42, 0.06);
+	padding: 1rem;
+}
+
+.cardTitle {
+	margin: 0;
+	color: #0f172a;
+	font-size: 1.03rem;
+}
+
+.summary {
+	margin: 0;
+	color: #334155;
+	line-height: 1.6;
+}
+
+.blockLabel {
+	margin: 0.35rem 0 0;
+	color: #0f172a;
+	font-weight: 700;
+	font-size: 0.86rem;
+	text-transform: uppercase;
+	letter-spacing: 0.03em;
+}
+
+.blockText {
+	margin: 0;
+	color: #475569;
+	line-height: 1.58;
+	font-size: 0.92rem;
+}
+
+.tags {
+	margin: 0.45rem 0 0;
+	padding: 0;
+	list-style: none;
+	display: flex;
+	flex-wrap: wrap;
+	gap: 0.42rem;
+}
+
+.tag {
+	border-radius: 999px;
+	border: 1px solid #d7e0ee;
+	background: #f8fbff;
+	color: #1e293b;
+	padding: 0.24rem 0.58rem;
+	font-size: 0.81rem;
+}
+
+.link {
+	margin-top: auto;
+	color: #0f172a;
+	font-weight: 600;
+	text-underline-offset: 2px;
+}
+
+.ctaRow {
+	margin-top: 1.2rem;
+	display: flex;
+	flex-wrap: wrap;
+	gap: 0.75rem;
+}
+
+.primaryCta,
+.secondaryCta {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	border-radius: 10px;
+	font-weight: 600;
+	text-decoration: none;
+	padding: 0.66rem 0.95rem;
+}
+
+.primaryCta {
+	background: #0f172a;
+	color: #ffffff;
+}
+
+.secondaryCta {
+	background: #ffffff;
+	color: #0f172a;
+	border: 1px solid #cbd5e1;
+}
+
+@media (max-width: 1024px) {
+	.grid {
+		grid-template-columns: repeat(2, minmax(0, 1fr));
+	}
+}
+
+@media (max-width: 700px) {
+	.section {
+		padding: 3.5rem 1rem;
+	}
+
+	.grid {
+		grid-template-columns: 1fr;
+	}
+
+	.ctaRow {
+		flex-direction: column;
+	}
+}

--- a/components/sectionProjects/sectionProjects.tsx
+++ b/components/sectionProjects/sectionProjects.tsx
@@ -93,7 +93,7 @@ export function SectionProjects() {
                   className={styles.link}
                   target="_blank"
                   rel="noopener noreferrer"
-                  aria-label={`Voir le lien public pour ${project.title}`}
+                  aria-label={`Voir le site de ${project.title} (lien externe)`}
                 >
                   Voir un lien public
                 </a>
@@ -106,8 +106,8 @@ export function SectionProjects() {
           <a href="#contact" className={styles.primaryCta}>
             Discuter de votre projet
           </a>
-          <a href="/images/resume/valentin-passe.webp" className={styles.secondaryCta} target="_blank" rel="noopener noreferrer">
-            Consulter le CV
+          <a href="#contact" className={styles.secondaryCta}>
+            Demander le CV
           </a>
         </div>
       </div>

--- a/components/sectionProjects/sectionProjects.tsx
+++ b/components/sectionProjects/sectionProjects.tsx
@@ -1,316 +1,116 @@
-// Libs
-import React from 'react';
+import React from "react";
+import styles from "./sectionProjects.module.scss";
 
-// Images
+type ProjectEntry = {
+  title: string;
+  summary: string;
+  context: string;
+  contribution: string;
+  outcome: string;
+  tags: string[];
+  publicLink?: string;
+};
 
-// CSS Module
-import styles from "./sectionProjects.module.scss"
+const PROJECTS: ProjectEntry[] = [
+  {
+    title: "Astreinte et interventions (SMEG)",
+    summary:
+      "Solution métier pour piloter appels d'astreinte, urgences et interventions sur usages bureau et mobile.",
+    context:
+      "Environnement opérationnel exigeant, avec contraintes de disponibilité et qualité de service continue.",
+    contribution:
+      "Conception et développement Fullstack sur socle .NET 7 / ABP, avec architecture orientée domaine.",
+    outcome:
+      "Digitalisation des processus terrain et meilleure réactivité des équipes dans les situations critiques.",
+    tags: [".NET", "C#", "ABP", "DDD", "Azure", "MongoDB"],
+  },
+  {
+    title: "Plateforme backend avec composante IA (TidyUp)",
+    summary:
+      "Base applicative pour le rangement, classement et la recherche de contenus numériques à forte valeur.",
+    context:
+      "Besoin d'une fondation backend robuste pour supporter l'évolution des fonctionnalités IA dans le temps.",
+    contribution:
+      "Développement backend en .NET MVC / .NET Core, structuration des flux techniques et de la persistance.",
+    outcome:
+      "Socle technique pérenne facilitant la montée en capacité produit et la fiabilité des traitements.",
+    tags: [".NET MVC", ".NET Core", "C#", "SQL", "Architecture"],
+  },
+  {
+    title: "Applications internes d'entreprise",
+    summary:
+      "Plusieurs projets internes menés sur des cycles longs pour soutenir les besoins métiers quotidiens.",
+    context:
+      "Contexte multi-applications avec enjeux de maintenabilité, performance et évolution progressive.",
+    contribution:
+      "Développement backend/fullstack, maintenance évolutive et amélioration continue de la qualité de delivery.",
+    outcome:
+      "Fiabilisation des processus internes et meilleure continuité de service pour les utilisateurs métiers.",
+    tags: [".NET", "Blazor", "Entity Framework", "SQL Server", "Delivery"],
+    publicLink: "https://c8g.fr",
+  },
+];
 
-// Data
-// import skillsData from "../../public/data/skills.json";
-
-export function SectionProjects () {
-//   interface Skill {
-//     label: string;
-//     description: string;
-//     category: SkillCategory;
-//     position: number;
-//   }
-
-//   enum SkillCategory {
-//     Technlology = "Technologie Microsoft",
-//     Database = "Base de donnée",
-//     Other = "Autre",
-//     Software = "Logiciel",
-//     OperatingSystem = "Système d'exploitation",
-//     Qualification = "Compétence"
-//   }
-
-//   const skills = skillsData; // converrt to skill
-
+export function SectionProjects() {
   return (
-    <section id="projects" className="content-section text-center">
-        {/* <div className="skills-section">
-            <div className="skills-container">
-                <h2>Skills</h2>
-                <div className="row pr-2">
-                    <div className="col-md-4 col-sm-6 col-xs-12">
-                        <div className="bloc-title-skills">
-                            <div className="title-skills"><span className="label label-primary">Technology</span></div>
-                        </div>
-                        <span className="label-progress">Microsoft .NET</span>
-                        <div className="progress">
-                            <div className="progress-bar progress-bar-striped active" role="progressbar" aria-valuenow="90" aria-valuemin="0" aria-valuemax="100" style="width: 90%">
-                                90%
-                                <span className="sr-only">90% Complete</span>
-                            </div>
-                        </div>
-                        <span className="label-progress">AJAX</span>
-                        <div className="progress">
-                            <div className="progress-bar progress-bar-striped active" role="progressbar" aria-valuenow="90" aria-valuemin="0" aria-valuemax="100" style="width: 90%">
-                                90%
-                                <span className="sr-only">90% Complete</span>
-                            </div>
-                        </div>
-                        <span className="label-progress">SSIS</span>
-                        <div className="progress">
-                            <div className="progress-bar progress-bar-striped active" role="progressbar" aria-valuenow="90" aria-valuemin="0" aria-valuemax="100" style="width: 90%">
-                                70%
-                                <span className="sr-only">90% Complete</span>
-                            </div>
-                        </div>
-                        <div className="bloc-title-skills">
-                            <div className="title-skills"><span className="label label-primary">language</span></div>
-                        </div>
-                        <span className="label-progress">HTML5</span>
-                        <div className="progress">
-                            <div className="progress-bar progress-bar-striped active" role="progressbar" aria-valuenow="95" aria-valuemin="0" aria-valuemax="100" style="width: 95%">
-                                95%
-                                <span className="sr-only">95% Complete</span>
-                            </div>
-                        </div>
-                        <span className="label-progress">CSS3</span>
-                        <div className="progress">
-                            <div className="progress-bar progress-bar-striped active" role="progressbar" aria-valuenow="95" aria-valuemin="0" aria-valuemax="100" style="width: 95%">
-                                95%
-                                <span className="sr-only">95% Complete</span>
-                            </div>
-                        </div>
-                        <span className="label-progress">JavaScript</span>
-                        <div className="progress">
-                            <div className="progress-bar progress-bar-striped active" role="progressbar" aria-valuenow="85" aria-valuemin="0" aria-valuemax="100" style="width: 85%">
-                                85%
-                                <span className="sr-only">85% Complete</span>
-                            </div>
-                        </div>
-                        <span className="label-progress">PHP</span>
-                        <div className="progress">
-                            <div className="progress-bar progress-bar-striped active" role="progressbar" aria-valuenow="60" aria-valuemin="0" aria-valuemax="100" style="width: 60%">
-                                60%
-                                <span className="sr-only">60% Complete</span>
-                            </div>
-                        </div>
-                        <span className="label-progress">ASP.NET</span>
-                        <div className="progress">
-                            <div className="progress-bar progress-bar-striped active" role="progressbar" aria-valuenow="90" aria-valuemin="0" aria-valuemax="100" style="width: 90%">
-                                90%
-                                <span className="sr-only">90% Complete</span>
-                            </div>
-                        </div>
-                        <span className="label-progress">SQL</span>
-                        <div className="progress">
-                            <div className="progress-bar progress-bar-striped active" role="progressbar" aria-valuenow="95" aria-valuemin="0" aria-valuemax="100" style="width: 95%">
-                                95%
-                                <span className="sr-only">95% Complete</span>
-                            </div>
-                        </div>
-                        <span className="label-progress">C#</span>
-                        <div className="progress">
-                            <div className="progress-bar progress-bar-striped active" role="progressbar" aria-valuenow="90" aria-valuemin="0" aria-valuemax="100" style="width: 90%">
-                                90%
-                                <span className="sr-only">90% Complete</span>
-                            </div>
-                        </div>
-                        <span className="label-progress">Java</span>
-                        <div className="progress">
-                            <div className="progress-bar progress-bar-striped active" role="progressbar" aria-valuenow="50" aria-valuemin="0" aria-valuemax="100" style="width: 50%">
-                                50%
-                                <span className="sr-only">50% Complete</span>
-                            </div>
-                        </div>
-                        <span className="label-progress">XML</span>
-                        <div className="progress">
-                            <div className="progress-bar progress-bar-striped active" role="progressbar" aria-valuenow="95" aria-valuemin="0" aria-valuemax="100" style="width: 95%">
-                                95%
-                                <span className="sr-only">95% Complete</span>
-                            </div>
-                        </div>
-                        <span className="label-progress">JSON</span>
-                        <div className="progress">
-                            <div className="progress-bar progress-bar-striped active" role="progressbar" aria-valuenow="95" aria-valuemin="0" aria-valuemax="100" style="width: 95%">
-                                95%
-                                <span className="sr-only">95% Complete</span>
-                            </div>
-                        </div>
-    
-                    </div>
-                    <div className="col-md-4 col-sm-6 col-xs-12">
-                        <div className="bloc-title-skills">
-                            <div className="title-skills"><span className="label label-info">Operating systems</span></div>
-                        </div>
-                        <span className="label-progress">Windows XP, Vista, 7, 8, 10</span>
-                        <div className="progress">
-                            <div className="progress-bar progress-bar-info progress-bar-striped active" role="progressbar" aria-valuenow="90" aria-valuemin="0" aria-valuemax="100" style="width: 90%">
-                                90%
-                                <span className="sr-only">90% Complete</span>
-                            </div>
-                        </div>
-                        <span className="label-progress">Mac OS X</span>
-                        <div className="progress">
-                            <div className="progress-bar progress-bar-info progress-bar-striped active" role="progressbar" aria-valuenow="75" aria-valuemin="0" aria-valuemax="100" style="width: 75%">
-                                75%
-                                <span className="sr-only">75% Complete</span>
-                            </div>
-                        </div>
-                        <span className="label-progress">Linux</span>
-                        <div className="progress">
-                            <div className="progress-bar progress-bar-info progress-bar-striped active" role="progressbar" aria-valuenow="50" aria-valuemin="0" aria-valuemax="100" style="width: 50%">
-                                50%
-                                <span className="sr-only">50% Complete</span>
-                            </div>
-                        </div>
-                        <div className="bloc-title-skills">
-                            <div className="title-skills"><span className="label label-danger">Database</span></div>
-                        </div>
-                        <span className="label-progress">SQL server</span>
-                        <div className="progress">
-                            <div className="progress-bar progress-bar-danger progress-bar-striped active" role="progressbar" aria-valuenow="90" aria-valuemin="0" aria-valuemax="100" style="width: 90%">
-                                90%
-                                <span className="sr-only">90% Complete</span>
-                            </div>
-                        </div>
-                        <span className="label-progress">Oracle</span>
-                        <div className="progress">
-                            <div className="progress-bar progress-bar-danger progress-bar-striped active" role="progressbar" aria-valuenow="70" aria-valuemin="0" aria-valuemax="100" style="width: 70%">
-                                70%
-                                <span className="sr-only">70% Complete (warning)</span>
-                            </div>
-                        </div>
-                        <span className="label-progress">MySQL</span>
-                        <div className="progress">
-                            <div className="progress-bar progress-bar-danger progress-bar-striped active" role="progressbar" aria-valuenow="80" aria-valuemin="0" aria-valuemax="100" style="width: 80%">
-                                80%
-                                <span className="sr-only">80% Complete</span>
-                            </div>
-                        </div>
-                        <div className="bloc-title-skills">
-                            <div className="title-skills"><span className="label label-warning">IDE &amp; Text Editor</span></div>
-                        </div>
-                        <span className="label-progress">VS 2010, 2012, 2013</span>
-                        <div className="progress">
-                            <div className="progress-bar progress-bar-warning progress-bar-striped active" role="progressbar" aria-valuenow="90" aria-valuemin="0" aria-valuemax="100" style="width: 90%">
-                                90%
-                                <span className="sr-only">90% Complete</span>
-                            </div>
-                        </div>
-                        <span className="label-progress">Adobe Dreamweaver</span>
-                        <div className="progress">
-                            <div className="progress-bar progress-bar-warning progress-bar-striped active" role="progressbar" aria-valuenow="70" aria-valuemin="0" aria-valuemax="100" style="width: 70%">
-                                70%
-                                <span className="sr-only">70% Complete</span>
-                            </div>
-                        </div>
-                        <span className="label-progress">PhpStorm</span>
-                        <div className="progress">
-                            <div className="progress-bar progress-bar-warning progress-bar-striped active" role="progressbar" aria-valuenow="60" aria-valuemin="0" aria-valuemax="100" style="width: 60%">
-                                60%
-                                <span className="sr-only">60% Complete</span>
-                            </div>
-                        </div>
-                        <span className="label-progress">Eclipse</span>
-                        <div className="progress">
-                            <div className="progress-bar progress-bar-warning progress-bar-striped active" role="progressbar" aria-valuenow="60" aria-valuemin="0" aria-valuemax="100" style="width: 60%">
-                                60%
-                                <span className="sr-only">60% Complete</span>
-                            </div>
-                        </div>
-                        <span className="label-progress">Sublime Text 2</span>
-                        <div className="progress">
-                            <div className="progress-bar progress-bar-warning progress-bar-striped active" role="progressbar" aria-valuenow="85" aria-valuemin="0" aria-valuemax="100" style="width: 85%">
-                                85%
-                                <span className="sr-only">85% Complete</span>
-                            </div>
-                        </div>
-                        <span className="label-progress">Notepad ++</span>
-                        <div className="progress">
-                            <div className="progress-bar progress-bar-warning progress-bar-striped active" role="progressbar" aria-valuenow="90" aria-valuemin="0" aria-valuemax="100" style="width: 90%">
-                                90%
-                                <span className="sr-only">90% Complete</span>
-                            </div>
-                        </div>
-                    <div className="col-md-4 col-sm-6 col-xs-12">
-                        <!-- Bloc Office software -->
-                        <div className="bloc-title-skills">
-                            <div className="title-skills"><span className="label label-success">Office software</span></div>
-                        </div>
-                        <span className="label-progress">Team Foundation Server (TFS)</span>
-                        <div className="progress">
-                            <div className="progress-bar progress-bar-success progress-bar-striped active" role="progressbar" aria-valuenow="85" aria-valuemin="0" aria-valuemax="100" style="width: 85%">
-                                85%
-                                <span className="sr-only">85% Complete</span>
-                            </div>
-                        </div>
-                        <span className="label-progress">Microsoft Office</span>
-                        <div className="progress">
-                            <div className="progress-bar progress-bar-success progress-bar-striped active" role="progressbar" aria-valuenow="90" aria-valuemin="0" aria-valuemax="100" style="width: 90%">
-                                90%
-                                <span className="sr-only">90% Complete</span>
-                            </div>
-                        </div>
-                        <span className="label-progress">iWorks (Mac)</span>
-                        <div className="progress">
-                            <div className="progress-bar progress-bar-success progress-bar-striped active" role="progressbar" aria-valuenow="90" aria-valuemin="0" aria-valuemax="100" style="width: 90%">
-                                90%
-                                <span className="sr-only">90% Complete</span>
-                            </div>
-                        </div>
-                        <span className="label-progress">Adobe Photoshop</span>
-                        <div className="progress">
-                            <div className="progress-bar progress-bar-success progress-bar-striped active" role="progressbar" aria-valuenow="80" aria-valuemin="0" aria-valuemax="100" style="width: 80%">
-                                80%
-                                <span className="sr-only">80% Complete</span>
-                            </div>
-                        </div>
-                        <span className="label-progress">Adobe InDesign</span>
-                        <div className="progress">
-                            <div className="progress-bar progress-bar-success progress-bar-striped active" role="progressbar" aria-valuenow="70" aria-valuemin="0" aria-valuemax="100" style="width: 70%">
-                                70%
-                                <span className="sr-only">70% Complete</span>
-                            </div>
-                        </div>
-                        <div className="bloc-title-skills">
-                            <div className="title-skills"><span className="label label-grey">qualifications</span></div>
-                        </div>
-                        <span className="label-progress">team spirit</span>
-                        <div className="progress">
-                            <div className="progress-bar progress-bar-grey progress-bar-striped active" role="progressbar" aria-valuenow="95" aria-valuemin="0" aria-valuemax="100" style="width: 95%">
-                                95%
-                                <span className="sr-only">95% Complete</span>
-                            </div>
-                        </div>
-                        <span className="label-progress">self-educated</span>
-                        <div className="progress">
-                            <div className="progress-bar progress-bar-grey progress-bar-striped active" role="progressbar" aria-valuenow="95" aria-valuemin="0" aria-valuemax="100" style="width: 95%">
-                                95%
-                                <span className="sr-only">95% Complete</span>
-                            </div>
-                        </div>
-                        <span className="label-progress">dynamic</span>
-                        <div className="progress">
-                            <div className="progress-bar progress-bar-grey progress-bar-striped active" role="progressbar" aria-valuenow="95" aria-valuemin="0" aria-valuemax="100" style="width: 95%">
-                                95%
-                                <span className="sr-only">95% Complete</span>
-                            </div>
-                        </div>
-                        <span className="label-progress">methodical</span>
-                        <div className="progress">
-                            <div className="progress-bar progress-bar-grey progress-bar-striped active" role="progressbar" aria-valuenow="95" aria-valuemin="0" aria-valuemax="100" style="width: 95%">
-                                95%
-                                <span className="sr-only">95% Complete</span>
-                            </div>
-                        </div>
-                        <span className="label-progress">autonomous</span>
-                        <div className="progress">
-                            <div className="progress-bar progress-bar-grey progress-bar-striped active" role="progressbar" aria-valuenow="95" aria-valuemin="0" aria-valuemax="100" style="width: 95%">
-                                95%
-                                <span className="sr-only">95% Complete</span>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-    
-            </div>
-        </div> */}
+    <section id="projects" className={styles.section} aria-labelledby="projects-title">
+      <div className={styles.container}>
+        <header className={styles.header}>
+          <h2 id="projects-title" className={styles.title}>
+            Projets
+          </h2>
+          <p className={styles.subtitle}>
+            Des cas concrets qui montrent comment je transforme un contexte métier en livraison utile.
+          </p>
+        </header>
+
+        <div className={styles.grid}>
+          {PROJECTS.map((project) => (
+            <article key={project.title} className={styles.card}>
+              <h3 className={styles.cardTitle}>{project.title}</h3>
+              <p className={styles.summary}>{project.summary}</p>
+
+              <p className={styles.blockLabel}>Contexte</p>
+              <p className={styles.blockText}>{project.context}</p>
+
+              <p className={styles.blockLabel}>Contribution</p>
+              <p className={styles.blockText}>{project.contribution}</p>
+
+              <p className={styles.blockLabel}>Résultat</p>
+              <p className={styles.blockText}>{project.outcome}</p>
+
+              <ul className={styles.tags} aria-label="Technologies et compétences projet">
+                {project.tags.map((tag) => (
+                  <li key={`${project.title}-${tag}`} className={styles.tag}>
+                    {tag}
+                  </li>
+                ))}
+              </ul>
+
+              {project.publicLink ? (
+                <a
+                  href={project.publicLink}
+                  className={styles.link}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  aria-label={`Voir le lien public pour ${project.title}`}
+                >
+                  Voir un lien public
+                </a>
+              ) : null}
+            </article>
+          ))}
+        </div>
+
+        <div className={styles.ctaRow}>
+          <a href="#contact" className={styles.primaryCta}>
+            Discuter de votre projet
+          </a>
+          <a href="/images/resume/valentin-passe.webp" className={styles.secondaryCta} target="_blank" rel="noopener noreferrer">
+            Consulter le CV
+          </a>
+        </div>
+      </div>
     </section>
   );
 }


### PR DESCRIPTION
## Summary
Implements the Projects Section for phase 1 with featured project cards and conversion CTAs.

## Implemented
- Replaced placeholder `SectionProjects` with 3 featured project cards.
- Added required narrative fields per project: summary, context, contribution, outcome.
- Added tags list per project.
- Added optional public link support (rendered only when present).
- Added section-level conversion CTA row to contact and CV.
- Added responsive card grid styling (desktop/tablet/mobile).

## Validation
- `npm run build` ✅

Closes #8