### PR TITLE
feat: one-page navigation (issue #11)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,34 +1,135 @@
-This is a [Next.js](https://nextjs.org/) project bootstrapped with [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packages/create-next-app).
+# Valentin Passe Portfolio
 
-## Getting Started
+Static-first portfolio built with Next.js and TypeScript for Valentin Passe, Fullstack .NET engineer. The site is designed as a premium one-page experience with bilingual French and English routes, anchored navigation, editorial content, and section-based storytelling.
 
-First, run the development server:
+## Stack
+
+- Next.js pages router
+- React 19
+- TypeScript
+- Sass Modules
+- next/font/google for typography
+- Jest for unit tests
+
+## Current Scope
+
+The active product scope includes:
+- hero section
+- about section
+- services section
+- skills section
+- work experience section
+- education section
+- projects section
+- contact section
+- one-page navigation
+- bilingual experience with French and English pages
+- premium visual redesign with gradients, glass effects, and restrained motion
+
+Removed from the active backlog:
+- CV download
+- standalone conversion reassurance feature
+
+## Routes
+
+- `/` French version
+- `/en` English version
+
+The language switch preserves the current section anchor when possible so visitors keep their browsing context while changing language.
+
+## Content Architecture
+
+Localized content is centralized in `content/portfolioContent.ts`.
+
+This file acts as the source of truth for:
+- metadata
+- navigation labels
+- hero copy and actions
+- about content
+- services
+- experience entries
+- education entries
+- projects
+- contact copy
+- footer labels
+
+The shared one-page composition lives in `components/homePage/homePage.tsx`, which renders the same section structure for both locales.
+
+## Project Structure
+
+```text
+components/
+  homePage/                  Shared one-page composition root
+  layout/                    Shell, metadata, header, footer
+  heroSection/               Intro section and key actions
+  sectionResume/             About section
+  sectionServices/           Services section
+  sectionSkills/             Skills section and normalization helpers
+  sectionWorkExperiences/    Experience section
+  sectionEducations/         Education section
+  sectionProjects/           Projects section
+  sectionContact/            Contact section
+content/
+  portfolioContent.ts        Localized portfolio content
+docs/
+  specs/                     Feature specifications still in scope
+  user-stories/              Matching user stories
+  implementation-overview.md High-level implementation summary
+pages/
+  index.tsx                  French route
+  en.tsx                     English route
+  _app.tsx                   Global fonts and app wrapper
+  _document.tsx              Locale-aware document lang
+styles/
+  globals.css                Design tokens and global styles
+  Home.module.css            Main page layout spacing
+```
+
+## Development
+
+Install dependencies:
+
+```bash
+npm install
+```
+
+Run the development server:
 
 ```bash
 npm run dev
-# or
-yarn dev
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+Build for production:
 
-You can start editing the page by modifying `pages/index.tsx`. The page auto-updates as you edit the file.
+```bash
+npm run build
+```
 
-[API routes](https://nextjs.org/docs/api-routes/introduction) can be accessed on [http://localhost:3000/api/hello](http://localhost:3000/api/hello). This endpoint can be edited in `pages/api/hello.ts`.
+Run tests:
 
-The `pages/api` directory is mapped to `/api/*`. Files in this directory are treated as [API routes](https://nextjs.org/docs/api-routes/introduction) instead of React pages.
+```bash
+npm run test
+```
 
-## Learn More
+## Implementation Notes
 
-To learn more about Next.js, take a look at the following resources:
+- The site uses static content instead of a runtime i18n library.
+- French is the default locale and English is exposed through a dedicated `/en` page.
+- Section anchors are shared across locales to keep navigation and language switching predictable.
+- Styling relies on CSS variables in `styles/globals.css` and section-level Sass modules.
+- Typography is loaded through `next/font/google` with Manrope for body text and Space Grotesk for display text.
 
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
+## Documentation
 
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js/) - your feedback and contributions are welcome!
+- `docs/specs/` contains the technical specifications for the remaining features in scope.
+- `docs/user-stories/` contains the corresponding product intent and acceptance criteria.
+- `docs/implementation-overview.md` summarizes the delivered architecture and current scope.
 
-## Deploy on Vercel
+## Quality Checks
 
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
+Recommended validation flow after changes:
 
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/deployment) for more details.
+```bash
+npm run build
+npm run test
+```

--- a/components/footerCustom/footerCustom.module.scss
+++ b/components/footerCustom/footerCustom.module.scss
@@ -1,0 +1,78 @@
+.footer {
+	position: relative;
+	z-index: 1;
+	padding: 2.5rem 1.25rem 3rem;
+	background: #09111b;
+	color: #f8fafc;
+}
+
+.container {
+	max-width: 1180px;
+	margin: 0 auto;
+	display: grid;
+	grid-template-columns: 1.4fr 0.8fr 0.8fr;
+	gap: 2rem;
+	padding-top: 2rem;
+	border-top: 1px solid rgba(148, 163, 184, 0.16);
+}
+
+.brandLink {
+	display: inline-flex;
+	align-items: center;
+	gap: 1rem;
+}
+
+.brandTitle {
+	margin: 0;
+	font-family: var(--font-display);
+	font-size: 1.05rem;
+	font-weight: 700;
+}
+
+.brandBaseline {
+	margin: 0.35rem 0 0;
+	max-width: 34ch;
+	line-height: 1.6;
+	color: rgba(226, 232, 240, 0.74);
+}
+
+.availability {
+	margin: 1rem 0 0;
+	max-width: 46ch;
+	line-height: 1.7;
+	color: rgba(226, 232, 240, 0.74);
+}
+
+.columnTitle {
+	margin: 0 0 0.75rem;
+	color: #93c5fd;
+	font-size: 0.76rem;
+	font-weight: 700;
+	letter-spacing: 0.14em;
+	text-transform: uppercase;
+}
+
+.linkList {
+	margin: 0;
+	padding: 0;
+	list-style: none;
+	display: grid;
+	gap: 0.55rem;
+}
+
+.linkList a,
+.emailLink {
+	color: #f8fafc;
+}
+
+.rights {
+	margin: 1rem 0 0;
+	color: rgba(226, 232, 240, 0.56);
+	line-height: 1.6;
+}
+
+@media (max-width: 900px) {
+	.container {
+		grid-template-columns: 1fr;
+	}
+}

--- a/components/footerCustom/footerCustom.tsx
+++ b/components/footerCustom/footerCustom.tsx
@@ -1,29 +1,50 @@
-// Libs
-import React from 'react';
-import Link from 'next/link';
-import Image from 'next/image';
+import React from "react";
+import Link from "next/link";
+import Image from "next/image";
+import LogoHeader from "../../public/images/header/logo.webp";
+import { PortfolioLocale, getPortfolioContent, portfolioEmail } from "../../content/portfolioContent";
+import styles from "./footerCustom.module.scss";
 
-// Images
-import LogoHeader from '../../public/images/header/logo.webp';
+type FooterCustomProps = {
+  locale: PortfolioLocale;
+};
 
-// CSS Module
-import styles from "./footerCustom.module.scss"
-// import { fontWeight } from '@mui/system';
+export function FooterCustom({ locale }: FooterCustomProps) {
+  const content = getPortfolioContent(locale).footer;
 
+  return (
+    <footer className={styles.footer}>
+      <div className={styles.container}>
+        <div className={styles.brandColumn}>
+          <Link href={locale === "en" ? "/en" : "/"} className={styles.brandLink}>
+            <Image src={LogoHeader} width={56} height={66} alt="Logo du portfolio de Valentin PASSE" />
+            <div>
+              <p className={styles.brandTitle}>Valentin Passe</p>
+              <p className={styles.brandBaseline}>{content.baseline}</p>
+            </div>
+          </Link>
+          <p className={styles.availability}>{content.availability}</p>
+        </div>
 
-export function FooterCustom () {
-    
-    return (
-        <footer className="container border-top">
-          <div className="d-flex flex-column align-items-center">
-            <Link href="/">
-                <Image src={LogoHeader} width="160" height="200" alt="Logo du portfolio de Valentin PASSE"></Image>
-            </Link>
-            <p>Développeur Web spécialisé dans la technologie Microsoft</p>
-            <p className="text-muted">
-              <small>© 2023 - Portfolio de Valentin PASSE, tous droits réservés.</small>
-            </p>
-          </div>
-        </footer>
-    );
-  }
+        <div className={styles.linksColumn}>
+          <p className={styles.columnTitle}>{content.navigationTitle}</p>
+          <ul className={styles.linkList}>
+            {content.links.map((item) => (
+              <li key={item.href}>
+                <a href={item.href}>{item.label}</a>
+              </li>
+            ))}
+          </ul>
+        </div>
+
+        <div className={styles.contactColumn}>
+          <p className={styles.columnTitle}>{content.contactTitle}</p>
+          <a href={`mailto:${portfolioEmail}`} className={styles.emailLink}>
+            {portfolioEmail}
+          </a>
+          <p className={styles.rights}>{content.rights}</p>
+        </div>
+      </div>
+    </footer>
+  );
+}

--- a/components/headerCustom/headerCustom.module.scss
+++ b/components/headerCustom/headerCustom.module.scss
@@ -98,8 +98,7 @@
 	gap: 0.5rem;
 }
 
-.contactCta,
-.cvCta {
+.contactCta {
 	display: inline-flex;
 	align-items: center;
 	justify-content: center;
@@ -108,18 +107,9 @@
 	font-size: 0.86rem;
 	font-weight: 700;
 	text-decoration: none;
-}
-
-.contactCta {
 	color: #ffffff;
 	background: #0f172a;
 	border: 1px solid #0f172a;
-}
-
-.cvCta {
-	color: #0f172a;
-	background: #ffffff;
-	border: 1px solid #cbd5e1;
 }
 
 .notice {
@@ -134,7 +124,6 @@
 .menuToggle:focus-visible,
 .navLink:focus-visible,
 .contactCta:focus-visible,
-.cvCta:focus-visible,
 .brand:focus-visible {
 	outline: 2px solid #0f172a;
 	outline-offset: 2px;
@@ -178,11 +167,10 @@
 
 	.ctaGroup {
 		display: grid;
-		grid-template-columns: 1fr 1fr;
+		grid-template-columns: 1fr;
 	}
 
-	.contactCta,
-	.cvCta {
+	.contactCta {
 		width: 100%;
 		min-height: 42px;
 	}

--- a/components/headerCustom/headerCustom.module.scss
+++ b/components/headerCustom/headerCustom.module.scss
@@ -1,0 +1,203 @@
+.header {
+	position: sticky;
+	top: 0;
+	z-index: 1000;
+	border-bottom: 1px solid #e2e8f0;
+	background: rgba(255, 255, 255, 0.96);
+	backdrop-filter: saturate(145%) blur(9px);
+}
+
+.nav {
+	max-width: 1180px;
+	margin: 0 auto;
+	padding: 0.75rem 1.25rem;
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 1rem;
+}
+
+.brand {
+	display: inline-flex;
+	align-items: center;
+	gap: 0.6rem;
+	color: #0f172a;
+	text-decoration: none;
+}
+
+.brandText {
+	font-size: 0.95rem;
+	letter-spacing: 0.01em;
+	white-space: nowrap;
+}
+
+.menuToggle {
+	display: none;
+	width: 42px;
+	height: 42px;
+	border: 1px solid #cbd5e1;
+	border-radius: 10px;
+	background: #ffffff;
+	padding: 0.5rem;
+	cursor: pointer;
+}
+
+.menuToggle span {
+	display: block;
+	width: 100%;
+	height: 2px;
+	margin: 5px 0;
+	background: #0f172a;
+	border-radius: 999px;
+}
+
+.navPanel {
+	display: flex;
+	align-items: center;
+	gap: 1rem;
+	margin-left: auto;
+}
+
+.navList {
+	margin: 0;
+	padding: 0;
+	list-style: none;
+	display: flex;
+	align-items: center;
+	gap: 0.25rem;
+}
+
+.navLink {
+	display: inline-flex;
+	align-items: center;
+	border-radius: 8px;
+	padding: 0.5rem 0.62rem;
+	color: #334155;
+	font-size: 0.9rem;
+	text-decoration: none;
+	border: 1px solid transparent;
+}
+
+.navLink:hover {
+	color: #0f172a;
+	background: #f1f5f9;
+}
+
+.navLinkActive {
+	color: #0f172a;
+	background: #ecf4ff;
+	border-color: #c8ddff;
+	font-weight: 700;
+	text-decoration: underline;
+	text-underline-offset: 3px;
+}
+
+.ctaGroup {
+	display: flex;
+	align-items: center;
+	gap: 0.5rem;
+}
+
+.contactCta,
+.cvCta {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	border-radius: 9px;
+	padding: 0.56rem 0.76rem;
+	font-size: 0.86rem;
+	font-weight: 700;
+	text-decoration: none;
+}
+
+.contactCta {
+	color: #ffffff;
+	background: #0f172a;
+	border: 1px solid #0f172a;
+}
+
+.cvCta {
+	color: #0f172a;
+	background: #ffffff;
+	border: 1px solid #cbd5e1;
+}
+
+.notice {
+	margin: 0;
+	min-height: 1.1rem;
+	color: #7c2d12;
+	font-size: 0.82rem;
+	max-width: 1180px;
+	padding: 0 1.25rem 0.45rem;
+}
+
+.menuToggle:focus-visible,
+.navLink:focus-visible,
+.contactCta:focus-visible,
+.cvCta:focus-visible,
+.brand:focus-visible {
+	outline: 2px solid #0f172a;
+	outline-offset: 2px;
+}
+
+@media (max-width: 1060px) {
+	.menuToggle {
+		display: inline-block;
+	}
+
+	.navPanel {
+		position: absolute;
+		top: calc(100% + 1px);
+		left: 0;
+		right: 0;
+		display: none;
+		flex-direction: column;
+		align-items: stretch;
+		gap: 0.8rem;
+		background: #ffffff;
+		border-bottom: 1px solid #e2e8f0;
+		padding: 0.9rem 1.2rem 1rem;
+	}
+
+	.navPanelOpen {
+		display: flex;
+	}
+
+	.navList {
+		display: grid;
+		grid-template-columns: 1fr;
+		gap: 0.2rem;
+	}
+
+	.navLink {
+		width: 100%;
+		justify-content: center;
+		font-size: 0.95rem;
+		padding: 0.68rem 0.8rem;
+	}
+
+	.ctaGroup {
+		display: grid;
+		grid-template-columns: 1fr 1fr;
+	}
+
+	.contactCta,
+	.cvCta {
+		width: 100%;
+		min-height: 42px;
+	}
+}
+
+@media (max-width: 600px) {
+	.brandText {
+		display: none;
+	}
+
+	.nav {
+		padding: 0.64rem 0.9rem;
+	}
+
+	.notice {
+		padding: 0 0.9rem 0.45rem;
+	}
+}

--- a/components/headerCustom/headerCustom.module.scss
+++ b/components/headerCustom/headerCustom.module.scss
@@ -2,43 +2,61 @@
 	position: sticky;
 	top: 0;
 	z-index: 1000;
-	border-bottom: 1px solid #e2e8f0;
-	background: rgba(255, 255, 255, 0.96);
-	backdrop-filter: saturate(145%) blur(9px);
+	padding: 1rem 1rem 0;
 }
 
 .nav {
-	max-width: 1180px;
+	max-width: 1240px;
 	margin: 0 auto;
-	padding: 0.75rem 1.25rem;
+	padding: 0.85rem 1rem;
 	display: flex;
 	align-items: center;
 	justify-content: space-between;
 	gap: 1rem;
+	border: 1px solid rgba(148, 163, 184, 0.24);
+	border-radius: 22px;
+	background: rgba(9, 17, 27, 0.78);
+	backdrop-filter: blur(18px) saturate(150%);
+	box-shadow: 0 18px 48px rgba(2, 8, 23, 0.24);
 }
 
 .brand {
 	display: inline-flex;
 	align-items: center;
-	gap: 0.6rem;
-	color: #0f172a;
+	gap: 0.8rem;
+	color: #f8fafc;
 	text-decoration: none;
 }
 
 .brandText {
-	font-size: 0.95rem;
-	letter-spacing: 0.01em;
+	display: flex;
+	flex-direction: column;
+	gap: 0.1rem;
 	white-space: nowrap;
+}
+
+.brandTitle {
+	font-family: var(--font-display);
+	font-size: 0.95rem;
+	font-weight: 700;
+	letter-spacing: 0.02em;
+}
+
+.brandSubtitle {
+	color: rgba(226, 232, 240, 0.72);
+	font-size: 0.74rem;
+	letter-spacing: 0.12em;
+	text-transform: uppercase;
 }
 
 .menuToggle {
 	display: none;
-	width: 42px;
-	height: 42px;
-	border: 1px solid #cbd5e1;
-	border-radius: 10px;
-	background: #ffffff;
-	padding: 0.5rem;
+	width: 44px;
+	height: 44px;
+	border: 1px solid rgba(148, 163, 184, 0.28);
+	border-radius: 14px;
+	background: rgba(15, 23, 42, 0.9);
+	padding: 0.55rem;
 	cursor: pointer;
 }
 
@@ -47,7 +65,7 @@
 	width: 100%;
 	height: 2px;
 	margin: 5px 0;
-	background: #0f172a;
+	background: #f8fafc;
 	border-radius: 999px;
 }
 
@@ -64,88 +82,101 @@
 	list-style: none;
 	display: flex;
 	align-items: center;
-	gap: 0.25rem;
+	gap: 0.35rem;
 }
 
 .navLink {
 	display: inline-flex;
 	align-items: center;
-	border-radius: 8px;
-	padding: 0.5rem 0.62rem;
-	color: #334155;
+	border-radius: 999px;
+	padding: 0.55rem 0.82rem;
+	color: rgba(226, 232, 240, 0.84);
 	font-size: 0.9rem;
 	text-decoration: none;
+	transition: color 0.22s ease, background-color 0.22s ease, border-color 0.22s ease;
 	border: 1px solid transparent;
 }
 
 .navLink:hover {
-	color: #0f172a;
-	background: #f1f5f9;
+	color: #ffffff;
+	background: rgba(148, 163, 184, 0.1);
 }
 
 .navLinkActive {
-	color: #0f172a;
-	background: #ecf4ff;
-	border-color: #c8ddff;
-	font-weight: 700;
-	text-decoration: underline;
-	text-underline-offset: 3px;
+	color: #ffffff;
+	background: rgba(47, 107, 255, 0.18);
+	border-color: rgba(96, 165, 250, 0.35);
+	box-shadow: inset 0 0 0 1px rgba(191, 219, 254, 0.08);
 }
 
-.ctaGroup {
+.utilityGroup {
 	display: flex;
 	align-items: center;
-	gap: 0.5rem;
+	gap: 0.6rem;
 }
 
+.localeSwitch,
 .contactCta {
 	display: inline-flex;
 	align-items: center;
 	justify-content: center;
-	border-radius: 9px;
-	padding: 0.56rem 0.76rem;
+	min-height: 42px;
+	padding: 0.62rem 0.92rem;
+	border-radius: 999px;
+	text-decoration: none;
 	font-size: 0.86rem;
 	font-weight: 700;
-	text-decoration: none;
-	color: #ffffff;
-	background: #0f172a;
-	border: 1px solid #0f172a;
+}
+
+.localeSwitch {
+	border: 1px solid rgba(148, 163, 184, 0.28);
+	color: #f8fafc;
+	background: rgba(148, 163, 184, 0.08);
+}
+
+.contactCta {
+	color: #09111b;
+	background: linear-gradient(135deg, #dbeafe 0%, #bfdbfe 45%, #f5d0a9 100%);
+	box-shadow: 0 12px 30px rgba(59, 130, 246, 0.24);
 }
 
 .notice {
-	margin: 0;
+	margin: 0.45rem auto 0;
 	min-height: 1.1rem;
-	color: #7c2d12;
+	max-width: 1240px;
+	padding: 0 1rem;
+	color: #f59e0b;
 	font-size: 0.82rem;
-	max-width: 1180px;
-	padding: 0 1.25rem 0.45rem;
 }
 
 .menuToggle:focus-visible,
 .navLink:focus-visible,
 .contactCta:focus-visible,
-.brand:focus-visible {
-	outline: 2px solid #0f172a;
-	outline-offset: 2px;
+.brand:focus-visible,
+.localeSwitch:focus-visible {
+	outline: 2px solid #bfdbfe;
+	outline-offset: 3px;
 }
 
-@media (max-width: 1060px) {
+@media (max-width: 1100px) {
 	.menuToggle {
 		display: inline-block;
 	}
 
 	.navPanel {
 		position: absolute;
-		top: calc(100% + 1px);
-		left: 0;
-		right: 0;
+		top: calc(100% + 0.65rem);
+		left: 1rem;
+		right: 1rem;
 		display: none;
 		flex-direction: column;
 		align-items: stretch;
-		gap: 0.8rem;
-		background: #ffffff;
-		border-bottom: 1px solid #e2e8f0;
-		padding: 0.9rem 1.2rem 1rem;
+		gap: 0.9rem;
+		padding: 1rem;
+		border-radius: 20px;
+		border: 1px solid rgba(148, 163, 184, 0.24);
+		background: rgba(9, 17, 27, 0.96);
+		box-shadow: 0 20px 44px rgba(2, 8, 23, 0.32);
 	}
 
 	.navPanelOpen {
@@ -155,37 +186,36 @@
 	.navList {
 		display: grid;
 		grid-template-columns: 1fr;
-		gap: 0.2rem;
 	}
 
 	.navLink {
-		width: 100%;
 		justify-content: center;
-		font-size: 0.95rem;
-		padding: 0.68rem 0.8rem;
 	}
 
-	.ctaGroup {
+	.utilityGroup {
 		display: grid;
-		grid-template-columns: 1fr;
-	}
-
-	.contactCta {
-		width: 100%;
-		min-height: 42px;
+		grid-template-columns: 1fr 1fr;
 	}
 }
 
-@media (max-width: 600px) {
-	.brandText {
+@media (max-width: 640px) {
+	.header {
+		padding: 0.8rem 0.8rem 0;
+	}
+
+	.brandSubtitle {
 		display: none;
 	}
 
-	.nav {
-		padding: 0.64rem 0.9rem;
+	.brandTitle {
+		font-size: 0.88rem;
 	}
 
-	.notice {
-		padding: 0 0.9rem 0.45rem;
+	.nav {
+		padding: 0.75rem 0.8rem;
+	}
+
+	.utilityGroup {
+		grid-template-columns: 1fr;
 	}
 }

--- a/components/headerCustom/headerCustom.tsx
+++ b/components/headerCustom/headerCustom.tsx
@@ -24,37 +24,10 @@ const NAV_ITEMS: NavigationItem[] = [
   { id: "contact", label: "Contact", route: "#contact" },
 ];
 
-const CV_FILE_PATH = "/cv/valentin-passe-cv.pdf";
-
 export function HeaderCustom() {
   const [activeSectionId, setActiveSectionId] = React.useState<string>("hero");
   const [isMenuOpen, setIsMenuOpen] = React.useState<boolean>(false);
-  const [cvAvailable, setCvAvailable] = React.useState<boolean>(true);
   const [notice, setNotice] = React.useState<string>("");
-
-  React.useEffect(() => {
-    if (typeof window === "undefined") {
-      return;
-    }
-
-    let cancelled = false;
-
-    fetch(CV_FILE_PATH, { method: "HEAD" })
-      .then((response) => {
-        if (!cancelled) {
-          setCvAvailable(response.ok);
-        }
-      })
-      .catch(() => {
-        if (!cancelled) {
-          setCvAvailable(false);
-        }
-      });
-
-    return () => {
-      cancelled = true;
-    };
-  }, []);
 
   React.useEffect(() => {
     if (typeof window === "undefined") {
@@ -125,24 +98,6 @@ export function HeaderCustom() {
     setIsMenuOpen(false);
   };
 
-  const handleCvAction = (event: React.MouseEvent<HTMLAnchorElement>) => {
-    if (cvAvailable) {
-      setNotice("");
-      setIsMenuOpen(false);
-      return;
-    }
-
-    event.preventDefault();
-    setNotice("Le CV n'est pas disponible en telechargement pour le moment. Vous pouvez me contacter directement.");
-    const contact = document.getElementById("contact");
-    if (contact) {
-      contact.scrollIntoView({ behavior: "smooth", block: "start" });
-      window.history.replaceState(null, "", "#contact");
-      setActiveSectionId("contact");
-    }
-    setIsMenuOpen(false);
-  };
-
   return (
     <header className={styles.header}>
       <nav className={styles.nav} aria-label="Navigation principale">
@@ -186,14 +141,6 @@ export function HeaderCustom() {
           <div className={styles.ctaGroup}>
             <a href="#contact" className={styles.contactCta} onClick={(event) => handleAnchorNavigation(event, "#contact", "contact")}>
               Me contacter
-            </a>
-            <a
-              href={cvAvailable ? CV_FILE_PATH : "#contact"}
-              className={styles.cvCta}
-              onClick={handleCvAction}
-              download={cvAvailable ? "CV-Valentin-Passe.pdf" : undefined}
-            >
-              CV
             </a>
           </div>
         </div>

--- a/components/headerCustom/headerCustom.tsx
+++ b/components/headerCustom/headerCustom.tsx
@@ -1,40 +1,30 @@
-// Libs
-import React from 'react';
-import Image from 'next/image';
+import React from "react";
+import Image from "next/image";
+import Logo from "../../public/images/header/logo.webp";
+import { PortfolioLocale, getPortfolioContent } from "../../content/portfolioContent";
+import styles from "./headerCustom.module.scss";
 
-// Images
-import Logo from '../../public/images/header/logo.webp';
-
-// CSS Module
-import styles from "./headerCustom.module.scss"
-
-type NavigationItem = {
-  id: string;
-  label: string;
-  route: string;
+type HeaderCustomProps = {
+  locale: PortfolioLocale;
 };
 
-const NAV_ITEMS: NavigationItem[] = [
-  { id: "hero", label: "Accueil", route: "#hero" },
-  { id: "about", label: "A propos", route: "#about" },
-  { id: "services", label: "Services", route: "#services" },
-  { id: "skills", label: "Competences", route: "#skills" },
-  { id: "experience", label: "Experience", route: "#experience" },
-  { id: "projects", label: "Projets", route: "#projects" },
-  { id: "contact", label: "Contact", route: "#contact" },
-];
-
-export function HeaderCustom() {
+export function HeaderCustom({ locale }: HeaderCustomProps) {
+  const content = getPortfolioContent(locale);
+  const navItems = content.navigation.items.map((item) => ({
+    ...item,
+    route: `#${item.id}`,
+  }));
   const [activeSectionId, setActiveSectionId] = React.useState<string>("hero");
   const [isMenuOpen, setIsMenuOpen] = React.useState<boolean>(false);
   const [notice, setNotice] = React.useState<string>("");
+  const otherLocaleHref = `${locale === "fr" ? "/en" : "/"}#${activeSectionId || "hero"}`;
 
   React.useEffect(() => {
     if (typeof window === "undefined") {
       return;
     }
 
-    const ids = NAV_ITEMS.map((item) => item.id);
+    const ids = navItems.map((item) => item.id);
     const sections = ids
       .map((id) => document.getElementById(id))
       .filter((section): section is HTMLElement => section !== null);
@@ -103,7 +93,10 @@ export function HeaderCustom() {
       <nav className={styles.nav} aria-label="Navigation principale">
         <a href="#hero" className={styles.brand} onClick={(event) => handleAnchorNavigation(event, "#hero", "hero")}>
           <Image src={Logo} width={44} height={52} alt="Logo Valentin PASSE" />
-          <span className={styles.brandText}><strong>VALENTIN</strong> PASSE</span>
+          <span className={styles.brandText}>
+            <span className={styles.brandTitle}>Valentin Passe</span>
+            <span className={styles.brandSubtitle}>Fullstack .NET</span>
+          </span>
         </a>
 
         <button
@@ -111,7 +104,7 @@ export function HeaderCustom() {
           className={styles.menuToggle}
           aria-expanded={isMenuOpen}
           aria-controls="portfolio-navigation"
-          aria-label="Ouvrir ou fermer le menu"
+          aria-label={locale === "fr" ? "Ouvrir ou fermer le menu" : "Open or close menu"}
           onClick={() => setIsMenuOpen((previous) => !previous)}
         >
           <span />
@@ -124,7 +117,7 @@ export function HeaderCustom() {
           className={`${styles.navPanel} ${isMenuOpen ? styles.navPanelOpen : ""}`.trim()}
         >
           <ul className={styles.navList}>
-            {NAV_ITEMS.map((item) => (
+            {navItems.map((item) => (
               <li key={item.id}>
                 <a
                   href={item.route}
@@ -138,9 +131,20 @@ export function HeaderCustom() {
             ))}
           </ul>
 
-          <div className={styles.ctaGroup}>
-            <a href="#contact" className={styles.contactCta} onClick={(event) => handleAnchorNavigation(event, "#contact", "contact")}>
-              Me contacter
+          <div className={styles.utilityGroup}>
+            <a
+              href={otherLocaleHref}
+              className={styles.localeSwitch}
+              aria-label={content.navigation.localeSwitcherLabel}
+            >
+              {content.switchLocaleLabel}
+            </a>
+            <a
+              href="#contact"
+              className={styles.contactCta}
+              onClick={(event) => handleAnchorNavigation(event, "#contact", "contact")}
+            >
+              {content.navigation.ctaLabel}
             </a>
           </div>
         </div>

--- a/components/headerCustom/headerCustom.tsx
+++ b/components/headerCustom/headerCustom.tsx
@@ -1,6 +1,5 @@
 // Libs
 import React from 'react';
-import Link from 'next/link';
 import Image from 'next/image';
 
 // Images
@@ -9,109 +8,200 @@ import Logo from '../../public/images/header/logo.webp';
 // CSS Module
 import styles from "./headerCustom.module.scss"
 
-export function HeaderCustom () {
-  interface Item {
-    label: string;
-    route: string;
-  }
+type NavigationItem = {
+  id: string;
+  label: string;
+  route: string;
+};
 
-  const items: Item[] = [
-    {
-      label: 'A propos de moi',
-      route: '#about',
-    },
-    {
-      label: 'Services',
-      route: '#services',
-    },
-    {
-      label: 'Compétences',
-      route: '#skills',
-    },
-    {
-      label: 'Expériences professionnelles',
-      route: '#experience',
-    },
-    {
-      label: 'Formations',
-      route: '#educations',
-    },
-    {
-      label: 'Projets',
-      route: '#projects',
-    },
-    {
-      label: 'Contact',
-      route: '#contact',
-    },
-  ];
+const NAV_ITEMS: NavigationItem[] = [
+  { id: "hero", label: "Accueil", route: "#hero" },
+  { id: "about", label: "A propos", route: "#about" },
+  { id: "services", label: "Services", route: "#services" },
+  { id: "skills", label: "Competences", route: "#skills" },
+  { id: "experience", label: "Experience", route: "#experience" },
+  { id: "projects", label: "Projets", route: "#projects" },
+  { id: "contact", label: "Contact", route: "#contact" },
+];
 
-  const [activeHash, setActiveHash] = React.useState<string>('');
+const CV_FILE_PATH = "/cv/valentin-passe-cv.pdf";
+
+export function HeaderCustom() {
+  const [activeSectionId, setActiveSectionId] = React.useState<string>("hero");
+  const [isMenuOpen, setIsMenuOpen] = React.useState<boolean>(false);
+  const [cvAvailable, setCvAvailable] = React.useState<boolean>(true);
+  const [notice, setNotice] = React.useState<string>("");
 
   React.useEffect(() => {
-    if (typeof window === 'undefined') {
+    if (typeof window === "undefined") {
       return;
     }
 
-    const updateHash = () => {
-      setActiveHash(window.location.hash || '');
-    };
+    let cancelled = false;
 
-    updateHash();
-    window.addEventListener('hashchange', updateHash);
+    fetch(CV_FILE_PATH, { method: "HEAD" })
+      .then((response) => {
+        if (!cancelled) {
+          setCvAvailable(response.ok);
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setCvAvailable(false);
+        }
+      });
 
     return () => {
-      window.removeEventListener('hashchange', updateHash);
+      cancelled = true;
     };
   }, []);
 
-  function getSelectedCss(currentRoute: string): string {
-    return currentRoute === activeHash ? 'selected' : '';
-  }
+  React.useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
 
-  function forceMenuToClosed(): void {
-    var navbarContent = document.getElementById('menuValentinPasse');
-    if (navbarContent) {
-      if (navbarContent.classList.contains('show')) {
-        navbarContent.classList.remove('show');
-      }
+    const ids = NAV_ITEMS.map((item) => item.id);
+    const sections = ids
+      .map((id) => document.getElementById(id))
+      .filter((section): section is HTMLElement => section !== null);
+
+    if (sections.length === 0) {
+      return;
     }
-    var navbarContent = document.getElementById('togglerMenuValentinPasse');
-    if (navbarContent) {
-      if (!navbarContent.classList.contains('collapsed')) {
-        navbarContent.classList.add('collapsed');
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        const visible = entries
+          .filter((entry) => entry.isIntersecting)
+          .sort((left, right) => right.intersectionRatio - left.intersectionRatio);
+
+        if (visible.length > 0) {
+          setActiveSectionId(visible[0].target.id);
+        }
+      },
+      {
+        root: null,
+        threshold: [0.25, 0.5, 0.75],
+        rootMargin: "-20% 0px -60% 0px",
       }
-      if (navbarContent.hasAttribute('aria-expanded')) {
-        navbarContent.setAttribute('aria-expanded', 'false');
+    );
+
+    sections.forEach((section) => observer.observe(section));
+
+    const updateFromHash = () => {
+      const hashId = window.location.hash.replace("#", "");
+      if (hashId && ids.includes(hashId)) {
+        setActiveSectionId(hashId);
       }
+    };
+
+    updateFromHash();
+    window.addEventListener("hashchange", updateFromHash);
+
+    return () => {
+      observer.disconnect();
+      window.removeEventListener("hashchange", updateFromHash);
+    };
+  }, []);
+
+  const handleAnchorNavigation = (event: React.MouseEvent<HTMLAnchorElement>, route: string, id: string) => {
+    if (typeof window === "undefined") {
+      return;
     }
-  }
+
+    event.preventDefault();
+    const target = document.querySelector(route);
+    if (!target) {
+      setNotice("La section demandee est temporairement indisponible. Vous pouvez continuer votre navigation.");
+      setIsMenuOpen(false);
+      return;
+    }
+
+    setNotice("");
+    target.scrollIntoView({ behavior: "smooth", block: "start" });
+    window.history.replaceState(null, "", route);
+    setActiveSectionId(id);
+    setIsMenuOpen(false);
+  };
+
+  const handleCvAction = (event: React.MouseEvent<HTMLAnchorElement>) => {
+    if (cvAvailable) {
+      setNotice("");
+      setIsMenuOpen(false);
+      return;
+    }
+
+    event.preventDefault();
+    setNotice("Le CV n'est pas disponible en telechargement pour le moment. Vous pouvez me contacter directement.");
+    const contact = document.getElementById("contact");
+    if (contact) {
+      contact.scrollIntoView({ behavior: "smooth", block: "start" });
+      window.history.replaceState(null, "", "#contact");
+      setActiveSectionId("contact");
+    }
+    setIsMenuOpen(false);
+  };
 
   return (
-    <header>
-      <nav className="navbar sticky-top navbar-expand-md bg-white border-bottom">
-        <div className="container-fluid">
-          <Link href="/" className="nav-brand d-flex">
-              <Image src={Logo} width={50} height={60} alt="Logo Valentin PASSE"></Image>
-              <span className="align-self-center h5 ps-2 mb-0"><b>VALENTIN</b> PASSE</span>
-          </Link>
-          <button className="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#menuValentinPasse" aria-controls="menuValentinPasse" aria-expanded="false" aria-label="Toggle navigation" id="togglerMenuValentinPasse">
-            <i className="fa-solid fa-bars"></i>
-          </button>
+    <header className={styles.header}>
+      <nav className={styles.nav} aria-label="Navigation principale">
+        <a href="#hero" className={styles.brand} onClick={(event) => handleAnchorNavigation(event, "#hero", "hero")}>
+          <Image src={Logo} width={44} height={52} alt="Logo Valentin PASSE" />
+          <span className={styles.brandText}><strong>VALENTIN</strong> PASSE</span>
+        </a>
 
-          <div className="collapse navbar-collapse" id="menuValentinPasse">
-            <ul className="navbar-nav ms-auto text-center mr-2">
-              {items.map((i) => (
-                <li className="nav-item my-auto" onClick={forceMenuToClosed} key={i.label}>
-                  <Link href={i.route} className={`nav-link ${getSelectedCss(i.route)}`}>
-                    {i.label}
-                  </Link>
-                </li>
-              ))}
-            </ul>
+        <button
+          type="button"
+          className={styles.menuToggle}
+          aria-expanded={isMenuOpen}
+          aria-controls="portfolio-navigation"
+          aria-label="Ouvrir ou fermer le menu"
+          onClick={() => setIsMenuOpen((previous) => !previous)}
+        >
+          <span />
+          <span />
+          <span />
+        </button>
+
+        <div
+          id="portfolio-navigation"
+          className={`${styles.navPanel} ${isMenuOpen ? styles.navPanelOpen : ""}`.trim()}
+        >
+          <ul className={styles.navList}>
+            {NAV_ITEMS.map((item) => (
+              <li key={item.id}>
+                <a
+                  href={item.route}
+                  className={`${styles.navLink} ${activeSectionId === item.id ? styles.navLinkActive : ""}`.trim()}
+                  aria-current={activeSectionId === item.id ? "page" : undefined}
+                  onClick={(event) => handleAnchorNavigation(event, item.route, item.id)}
+                >
+                  {item.label}
+                </a>
+              </li>
+            ))}
+          </ul>
+
+          <div className={styles.ctaGroup}>
+            <a href="#contact" className={styles.contactCta} onClick={(event) => handleAnchorNavigation(event, "#contact", "contact")}>
+              Me contacter
+            </a>
+            <a
+              href={cvAvailable ? CV_FILE_PATH : "#contact"}
+              className={styles.cvCta}
+              onClick={handleCvAction}
+              download={cvAvailable ? "CV-Valentin-Passe.pdf" : undefined}
+            >
+              CV
+            </a>
           </div>
         </div>
       </nav>
+
+      <p className={styles.notice} role="status" aria-live="polite">
+        {notice}
+      </p>
     </header>
   );
-  }
+}

--- a/components/heroSection/heroSection.module.scss
+++ b/components/heroSection/heroSection.module.scss
@@ -1,276 +1,378 @@
-// ── Keyframes ─────────────────────────────────────────────────────────────────
-
 @keyframes fadeInUp {
-  from {
-    opacity: 0;
-    transform: translateY(24px);
-  }
-  to {
-    opacity: 1;
-    transform: translateY(0);
-  }
+	from {
+		opacity: 0;
+		transform: translateY(24px);
+	}
+
+	to {
+		opacity: 1;
+		transform: translateY(0);
+	}
 }
 
 @keyframes spin {
-  from { transform: rotate(0deg); }
-  to   { transform: rotate(360deg); }
+	from {
+		transform: rotate(0deg);
+	}
+
+	to {
+		transform: rotate(360deg);
+	}
 }
 
 @keyframes spinReverse {
-  from { transform: rotate(0deg); }
-  to   { transform: rotate(-360deg); }
+	from {
+		transform: rotate(0deg);
+	}
+
+	to {
+		transform: rotate(-360deg);
+	}
 }
 
 @keyframes pulse {
-  0%, 100% { transform: scale(1); }
-  50%       { transform: scale(1.04); }
-}
+	0%,
+	100% {
+		transform: scale(1);
+	}
 
-// ── Section ───────────────────────────────────────────────────────────────────
+	50% {
+		transform: scale(1.03);
+	}
+}
 
 .hero {
-  min-height: 100vh;
-  background-color: #0d0d0d;
-  color: #ffffff;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 3rem;
-  padding: 6rem 8%;
+	min-height: 100vh;
+	position: relative;
+	color: #ffffff;
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 4rem;
+	padding: 7rem 7% 5rem;
+	overflow: hidden;
+	background:
+		radial-gradient(circle at 20% 18%, rgba(47, 107, 255, 0.28), transparent 30%),
+		radial-gradient(circle at 82% 16%, rgba(198, 139, 89, 0.18), transparent 24%),
+		linear-gradient(180deg, rgba(9, 17, 27, 0.96) 0%, rgba(12, 21, 33, 0.98) 100%);
 
-  @media (max-width: 768px) {
-    flex-direction: column;
-    justify-content: center;
-    padding: 5rem 6% 4rem;
-    text-align: center;
-  }
+	&::before {
+		content: "";
+		position: absolute;
+		inset: 0;
+		pointer-events: none;
+		background-image:
+			linear-gradient(rgba(148, 163, 184, 0.08) 1px, transparent 1px),
+			linear-gradient(90deg, rgba(148, 163, 184, 0.08) 1px, transparent 1px);
+		background-size: 92px 92px;
+		opacity: 0.35;
+	}
+
+	@media (max-width: 768px) {
+		flex-direction: column;
+		justify-content: center;
+		padding: 6.5rem 6% 4rem;
+		text-align: center;
+	}
 }
-
-// ── Content (left column) ─────────────────────────────────────────────────────
 
 .content {
-  flex: 1;
-  max-width: 640px;
-  animation: fadeInUp 0.7s ease both;
+	position: relative;
+	z-index: 1;
+	flex: 1;
+	max-width: 720px;
+	animation: fadeInUp 0.7s ease both;
 
-  @media (prefers-reduced-motion: reduce) {
-    animation: none;
-  }
+	@media (prefers-reduced-motion: reduce) {
+		animation: none;
+	}
 }
 
-// ── Headline ──────────────────────────────────────────────────────────────────
-
 .headline {
-  margin-bottom: 1.5rem;
+	margin-bottom: 1.2rem;
+}
+
+.eyebrow {
+	margin: 0 0 0.9rem;
+	color: #bfd7ff;
+	font-size: 0.85rem;
+	font-weight: 700;
+	letter-spacing: 0.16em;
+	text-transform: uppercase;
 }
 
 .name {
-  font-size: clamp(2.4rem, 5vw, 3.6rem);
-  font-weight: 800;
-  letter-spacing: -0.03em;
-  margin: 0 0 0.5rem;
-  line-height: 1.1;
+	margin: 0;
+	font-family: var(--font-display);
+	font-size: clamp(3rem, 6vw, 5.3rem);
+	font-weight: 800;
+	letter-spacing: -0.03em;
+	line-height: 0.98;
+	text-transform: uppercase;
 }
 
 .tagline {
-  font-size: clamp(1rem, 2vw, 1.2rem);
-  font-weight: 400;
-  color: #a0a0a0;
-  margin: 0;
-  letter-spacing: 0.01em;
+	max-width: 22ch;
+	font-size: clamp(1.2rem, 2vw, 1.5rem);
+	font-weight: 500;
+	color: rgba(241, 245, 249, 0.88);
+	margin: 1rem 0 0;
+	line-height: 1.35;
 }
-
-// ── Service promise ───────────────────────────────────────────────────────────
 
 .promise {
-  font-size: clamp(1rem, 1.5vw, 1.125rem);
-  line-height: 1.7;
-  color: #cccccc;
-  margin: 0 0 2rem;
-  max-width: 520px;
+	font-size: clamp(1rem, 1.45vw, 1.12rem);
+	line-height: 1.82;
+	color: rgba(226, 232, 240, 0.8);
+	margin: 0 0 2.25rem;
+	max-width: 60ch;
 
-  @media (max-width: 768px) {
-    max-width: 100%;
-  }
+	@media (max-width: 768px) {
+		max-width: 100%;
+	}
 }
 
-// ── Proof points ──────────────────────────────────────────────────────────────
-
 .proofPoints {
-  list-style: none;
-  padding: 0;
-  margin: 0 0 2.5rem;
-  display: flex;
-  flex-direction: column;
-  gap: 0.6rem;
+	list-style: none;
+	padding: 0;
+	margin: 0 0 2rem;
+	display: flex;
+	flex-direction: column;
+	gap: 0.8rem;
 }
 
 .proofPoint {
-  display: flex;
-  align-items: center;
-  gap: 0.6rem;
-  font-size: 0.95rem;
-  color: #e0e0e0;
+	display: flex;
+	align-items: flex-start;
+	gap: 0.7rem;
+	font-size: 0.95rem;
+	line-height: 1.6;
+	color: rgba(226, 232, 240, 0.88);
 
-  @media (max-width: 768px) {
-    justify-content: center;
-  }
+	@media (max-width: 768px) {
+		text-align: left;
+	}
 }
 
 .proofIcon {
-  color: #4ade80;
-  font-weight: 700;
-  font-size: 1rem;
-  flex-shrink: 0;
+	color: #8ad7ff;
+	font-weight: 700;
+	font-size: 1rem;
+	flex-shrink: 0;
+	margin-top: 0.18rem;
 }
 
-// ── Action group ──────────────────────────────────────────────────────────────
-
 .actionGroup {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.875rem;
+	display: flex;
+	flex-wrap: wrap;
+	gap: 0.9rem;
+	margin-bottom: 2rem;
 
-  @media (max-width: 768px) {
-    justify-content: center;
-  }
+	@media (max-width: 768px) {
+		justify-content: center;
+	}
 }
 
 .btn {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  padding: 0.7rem 1.5rem;
-  border-radius: 6px;
-  font-size: 0.95rem;
-  font-weight: 600;
-  cursor: pointer;
-  text-decoration: none;
-  transition: background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease,
-    transform 0.15s ease;
-  white-space: nowrap;
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	min-height: 52px;
+	padding: 0.85rem 1.4rem;
+	border-radius: 999px;
+	font-size: 0.94rem;
+	font-weight: 600;
+	cursor: pointer;
+	text-decoration: none;
+	transition: background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease,
+		transform 0.15s ease;
+	white-space: nowrap;
 
-  &:focus-visible {
-    outline: 2px solid #ffffff;
-    outline-offset: 3px;
-  }
+	&:focus-visible {
+		outline: 2px solid #ffffff;
+		outline-offset: 3px;
+	}
 
-  &:hover {
-    transform: translateY(-2px);
-  }
+	&:hover {
+		transform: translateY(-2px);
+	}
 
-  &:active {
-    transform: translateY(0);
-  }
+	&:active {
+		transform: translateY(0);
+	}
 
-  @media (prefers-reduced-motion: reduce) {
-    transition: none;
-    &:hover { transform: none; }
-  }
+	@media (prefers-reduced-motion: reduce) {
+		transition: none;
+
+		&:hover {
+			transform: none;
+		}
+	}
 }
 
 .btnPrimary {
-  background-color: #ffffff;
-  color: #0d0d0d;
-  border: 2px solid transparent;
-
-  &:hover {
-    background-color: #e5e5e5;
-  }
+	background: linear-gradient(135deg, #dbeafe 0%, #bfdbfe 45%, #f5d0a9 100%);
+	color: #09111b;
+	border: 2px solid transparent;
+	box-shadow: 0 14px 32px rgba(59, 130, 246, 0.2);
 }
 
 .btnOutline {
-  background-color: transparent;
-  color: #ffffff;
-  border: 2px solid rgba(255, 255, 255, 0.5);
+	background-color: rgba(148, 163, 184, 0.08);
+	color: #ffffff;
+	border: 2px solid rgba(255, 255, 255, 0.18);
 
-  &:hover {
-    border-color: #ffffff;
-    background-color: rgba(255, 255, 255, 0.08);
-  }
+	&:hover {
+		border-color: #ffffff;
+		background-color: rgba(255, 255, 255, 0.12);
+	}
 }
 
-// ── Visual (right column) ─────────────────────────────────────────────────────
+.metrics {
+	display: grid;
+	grid-template-columns: repeat(3, minmax(0, 1fr));
+	gap: 0.9rem;
+	max-width: 780px;
+
+	@media (max-width: 900px) {
+		grid-template-columns: 1fr;
+	}
+}
+
+.metricCard {
+	padding: 1rem 1.05rem;
+	border-radius: 20px;
+	border: 1px solid rgba(148, 163, 184, 0.2);
+	background: rgba(15, 23, 42, 0.56);
+	backdrop-filter: blur(10px);
+}
+
+.metricValue {
+	margin: 0;
+	font-family: var(--font-display);
+	font-size: 1.8rem;
+	color: #f8fafc;
+}
+
+.metricLabel {
+	margin: 0.42rem 0 0;
+	color: rgba(226, 232, 240, 0.74);
+	line-height: 1.5;
+}
 
 .visual {
-  flex-shrink: 0;
-  position: relative;
-  width: 280px;
-  height: 280px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
+	position: relative;
+	flex-shrink: 0;
+	width: min(38vw, 480px);
+	min-width: 320px;
+	height: min(38vw, 480px);
+	display: flex;
+	align-items: center;
+	justify-content: center;
 
-  @media (max-width: 768px) {
-    width: 200px;
-    height: 200px;
-    order: -1;
-  }
+	@media (max-width: 768px) {
+		min-width: 0;
+		width: min(86vw, 360px);
+		height: min(86vw, 360px);
+		order: -1;
+	}
 }
 
-.avatar {
-  width: 140px;
-  height: 140px;
-  border-radius: 50%;
-  background: linear-gradient(135deg, #1f1f1f 0%, #333333 100%);
-  border: 2px solid rgba(255, 255, 255, 0.12);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  z-index: 1;
-  animation: pulse 4s ease-in-out infinite;
+.visualCard {
+	position: relative;
+	z-index: 1;
+	width: 100%;
+	height: 100%;
+	border-radius: 36px;
+	border: 1px solid rgba(148, 163, 184, 0.22);
+	background:
+		linear-gradient(180deg, rgba(14, 23, 37, 0.76) 0%, rgba(18, 31, 49, 0.92) 100%),
+		radial-gradient(circle at top, rgba(47, 107, 255, 0.18), transparent 40%);
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	padding: 1.2rem;
+	box-shadow: 0 30px 80px rgba(2, 8, 23, 0.36);
+	animation: pulse 4s ease-in-out infinite;
 
-  @media (max-width: 768px) {
-    width: 100px;
-    height: 100px;
-  }
-
-  @media (prefers-reduced-motion: reduce) {
-    animation: none;
-  }
+	@media (prefers-reduced-motion: reduce) {
+		animation: none;
+	}
 }
 
-.initials {
-  font-size: 2rem;
-  font-weight: 700;
-  color: #ffffff;
-  letter-spacing: 0.05em;
+.portraitShell {
+	position: absolute;
+	inset: 1.2rem 3.2rem 3.6rem 1.2rem;
+	border-radius: 28px;
+	overflow: hidden;
+	border: 1px solid rgba(191, 219, 254, 0.2);
+}
 
-  @media (max-width: 768px) {
-    font-size: 1.5rem;
-  }
+.portrait {
+	width: 100%;
+	height: 100%;
+	object-fit: cover;
+	filter: saturate(0.88) contrast(1.05);
+}
+
+.floatingPanel {
+	position: absolute;
+	right: -0.8rem;
+	bottom: 2rem;
+	width: min(54%, 220px);
+	padding: 0.9rem 1rem;
+	border-radius: 18px;
+	background: rgba(241, 245, 249, 0.94);
+	color: #0f172a;
+	border: 1px solid rgba(148, 163, 184, 0.2);
+}
+
+.floatingLabel {
+	margin: 0;
+	font-size: 0.72rem;
+	font-weight: 700;
+	letter-spacing: 0.12em;
+	text-transform: uppercase;
+	color: #3b82f6;
+}
+
+.floatingValue {
+	margin: 0.45rem 0 0;
+	line-height: 1.45;
+	font-size: 0.88rem;
+	font-weight: 600;
 }
 
 .ring {
-  position: absolute;
-  inset: 0;
-  border-radius: 50%;
-  border: 2px solid transparent;
-  border-top-color: rgba(255, 255, 255, 0.25);
-  border-right-color: rgba(255, 255, 255, 0.08);
-  animation: spin 8s linear infinite;
+	position: absolute;
+	inset: -2rem;
+	border-radius: 40px;
+	border: 1px solid transparent;
+	border-top-color: rgba(191, 219, 254, 0.22);
+	border-right-color: rgba(191, 219, 254, 0.1);
+	animation: spin 16s linear infinite;
 
-  @media (prefers-reduced-motion: reduce) {
-    animation: none;
-    border-color: rgba(255, 255, 255, 0.1);
-  }
+	@media (prefers-reduced-motion: reduce) {
+		animation: none;
+		border-color: rgba(255, 255, 255, 0.1);
+	}
 }
 
 .ring2 {
-  position: absolute;
-  inset: 16px;
-  border-radius: 50%;
-  border: 1px solid transparent;
-  border-bottom-color: rgba(74, 222, 128, 0.3);
-  border-left-color: rgba(74, 222, 128, 0.1);
-  animation: spinReverse 12s linear infinite;
+	position: absolute;
+	inset: 1rem;
+	border-radius: 30px;
+	border: 1px solid transparent;
+	border-bottom-color: rgba(198, 139, 89, 0.34);
+	border-left-color: rgba(198, 139, 89, 0.16);
+	animation: spinReverse 12s linear infinite;
 
-  @media (max-width: 768px) {
-    inset: 12px;
-  }
+	@media (max-width: 768px) {
+		inset: 0.8rem;
+	}
 
-  @media (prefers-reduced-motion: reduce) {
-    animation: none;
-    border-color: rgba(74, 222, 128, 0.15);
-  }
+	@media (prefers-reduced-motion: reduce) {
+		animation: none;
+		border-color: rgba(198, 139, 89, 0.15);
+	}
 }

--- a/components/heroSection/heroSection.tsx
+++ b/components/heroSection/heroSection.tsx
@@ -1,25 +1,27 @@
 import React from "react";
+import Image from "next/image";
+import Profile from "../../public/images/resume/valentin-passe.webp";
+import { PortfolioLocale, getPortfolioContent } from "../../content/portfolioContent";
 import styles from "./heroSection.module.scss";
 
-// ── Sub-components ──────────────────────────────────────────────────────────
+type HeroSectionProps = {
+  locale?: PortfolioLocale;
+};
 
-function HeroHeadline() {
+function HeroHeadline({ locale = "fr" }: HeroSectionProps) {
+  const content = getPortfolioContent(locale).hero;
+
   return (
     <div className={styles.headline}>
-      <h1 className={styles.name}>Valentin Passe</h1>
-      <p className={styles.tagline}>
-        Développeur Fullstack&nbsp;.NET&nbsp;·&nbsp;Freelance&nbsp;·&nbsp;Solutions IA stratégiques
-      </p>
+      <p className={styles.eyebrow}>{content.eyebrow}</p>
+      <h1 className={styles.name}>{content.name}</h1>
+      <p className={styles.tagline}>{content.tagline}</p>
     </div>
   );
 }
 
-function HeroProofPoints() {
-  const points = [
-    "+10 ans d'expérience Fullstack .NET",
-    "Expertise IA appliquée aux entreprises",
-    "Disponible pour missions freelance",
-  ];
+function HeroProofPoints({ locale = "fr" }: HeroSectionProps) {
+  const points = getPortfolioContent(locale).hero.proofPoints;
 
   return (
     <ul className={styles.proofPoints} aria-label="Points clés">
@@ -33,23 +35,40 @@ function HeroProofPoints() {
   );
 }
 
-function HeroActionGroup() {
+function HeroActionGroup({ locale = "fr" }: HeroSectionProps) {
+  const content = getPortfolioContent(locale).hero;
+
   return (
     <div className={styles.actionGroup} role="group" aria-label="Actions principales">
       <a
-        href="mailto:passe.valentin@gmail.com"
+        href={content.primaryAction.href}
         className={`${styles.btn} ${styles.btnPrimary}`}
-        aria-label="Envoyer un e-mail à Valentin Passe"
+        aria-label={content.primaryAction.label}
       >
-        Me contacter
+        {content.primaryAction.label}
       </a>
       <a
-        href="#projects"
+        href={content.secondaryAction.href}
         className={`${styles.btn} ${styles.btnOutline}`}
-        aria-label="Voir les projets de Valentin Passe"
+        aria-label={content.secondaryAction.label}
       >
-        Voir mes projets
+        {content.secondaryAction.label}
       </a>
+    </div>
+  );
+}
+
+function HeroMetrics({ locale = "fr" }: HeroSectionProps) {
+  const metrics = getPortfolioContent(locale).hero.metrics;
+
+  return (
+    <div className={styles.metrics}>
+      {metrics.map((metric) => (
+        <article key={`${metric.value}-${metric.label}`} className={styles.metricCard}>
+          <p className={styles.metricValue}>{metric.value}</p>
+          <p className={styles.metricLabel}>{metric.label}</p>
+        </article>
+      ))}
     </div>
   );
 }
@@ -57,8 +76,20 @@ function HeroActionGroup() {
 function HeroVisual() {
   return (
     <div className={styles.visual} aria-hidden="true">
-      <div className={styles.avatar}>
-        <span className={styles.initials}>VP</span>
+      <div className={styles.visualCard}>
+        <div className={styles.portraitShell}>
+          <Image
+            src={Profile}
+            alt="Portrait de Valentin Passe"
+            className={styles.portrait}
+            sizes="(max-width: 900px) 240px, 360px"
+            priority
+          />
+        </div>
+        <div className={styles.floatingPanel}>
+          <p className={styles.floatingLabel}>Delivery focus</p>
+          <p className={styles.floatingValue}>Architecture .NET, Blazor, IA utile</p>
+        </div>
       </div>
       <div className={styles.ring} />
       <div className={styles.ring2} />
@@ -66,19 +97,17 @@ function HeroVisual() {
   );
 }
 
-// ── Main component ───────────────────────────────────────────────────────────
+export function HeroSection({ locale = "fr" }: HeroSectionProps) {
+  const content = getPortfolioContent(locale).hero;
 
-export function HeroSection() {
   return (
     <section id="hero" className={styles.hero} aria-label="Introduction">
       <div className={styles.content}>
-        <HeroHeadline />
-        <p className={styles.promise}>
-          Je conçois des applications web robustes, du back&#8209;end&nbsp;.NET
-          à l&apos;interface Blazor.
-        </p>
-        <HeroProofPoints />
-        <HeroActionGroup />
+        <HeroHeadline locale={locale} />
+        <p className={styles.promise}>{content.promise}</p>
+        <HeroProofPoints locale={locale} />
+        <HeroActionGroup locale={locale} />
+        <HeroMetrics locale={locale} />
       </div>
       <HeroVisual />
     </section>

--- a/components/heroSection/heroSection.tsx
+++ b/components/heroSection/heroSection.tsx
@@ -70,7 +70,7 @@ function HeroVisual() {
 
 export function HeroSection() {
   return (
-    <section className={styles.hero} aria-label="Introduction">
+    <section id="hero" className={styles.hero} aria-label="Introduction">
       <div className={styles.content}>
         <HeroHeadline />
         <p className={styles.promise}>

--- a/components/homePage/homePage.tsx
+++ b/components/homePage/homePage.tsx
@@ -1,0 +1,45 @@
+import React from "react";
+import { Layout } from "../layout";
+import { Hr } from "../hr";
+import { HeroSection } from "../heroSection";
+import { SectionContact } from "../sectionContact";
+import { SectionResume } from "../sectionResume";
+import { SectionServices } from "../sectionServices";
+import { SectionSkills } from "../sectionSkills";
+import { SectionWorkExperiences } from "../sectionWorkExperiences";
+import { SectionEducations } from "../sectionEducations";
+import { SectionProjects } from "../sectionProjects";
+import { PortfolioLocale, getPortfolioContent } from "../../content/portfolioContent";
+import styles from "../../styles/Home.module.css";
+
+type HomePageProps = {
+  locale: PortfolioLocale;
+};
+
+export function HomePage({ locale }: HomePageProps) {
+  const content = getPortfolioContent(locale);
+
+  return (
+    <Layout locale={locale} title={content.meta.title} description={content.meta.description}>
+      <main className={styles.page}>
+        <HeroSection locale={locale} />
+        <div className={styles.container}>
+          <div className={styles.stack}>
+            <SectionResume locale={locale} />
+            <Hr />
+            <SectionServices locale={locale} />
+            <Hr />
+            <SectionSkills locale={locale} />
+            <Hr />
+            <SectionWorkExperiences locale={locale} />
+            <Hr />
+            <SectionEducations locale={locale} />
+            <Hr />
+            <SectionProjects locale={locale} />
+          </div>
+        </div>
+        <SectionContact locale={locale} />
+      </main>
+    </Layout>
+  );
+}

--- a/components/homePage/index.tsx
+++ b/components/homePage/index.tsx
@@ -1,0 +1,1 @@
+export * from "./homePage";

--- a/components/hr/hr.jsx
+++ b/components/hr/hr.jsx
@@ -1,6 +1,9 @@
-// CSS Module
-import styles from "./hr.module.css"
+import styles from "./hr.module.css";
 
 export function Hr() {
-    return <div className={styles.hr}></div>
+    return (
+        <div className={styles.hr} aria-hidden="true">
+            <span className={styles.dot} />
+        </div>
+    );
 }

--- a/components/hr/hr.module.css
+++ b/components/hr/hr.module.css
@@ -1,5 +1,19 @@
 .hr {
-    height: 2px;
-    width: 100%;
-    border-bottom: 2px solid #0f458a;
+    position: relative;
+    width: min(1120px, calc(100% - 2rem));
+    height: 1px;
+    margin: 0 auto;
+    background: linear-gradient(90deg, transparent 0%, rgba(148, 163, 184, 0.42) 18%, rgba(59, 130, 246, 0.34) 50%, rgba(148, 163, 184, 0.42) 82%, transparent 100%);
+}
+
+.dot {
+    position: absolute;
+    left: 50%;
+    top: 50%;
+    width: 10px;
+    height: 10px;
+    transform: translate(-50%, -50%);
+    border-radius: 50%;
+    background: linear-gradient(135deg, #bfdbfe 0%, #f5d0a9 100%);
+    box-shadow: 0 0 0 8px rgba(255, 255, 255, 0.8), 0 0 18px rgba(59, 130, 246, 0.2);
 }

--- a/components/layout/layout.module.scss
+++ b/components/layout/layout.module.scss
@@ -1,0 +1,26 @@
+.mainContainer {
+	position: relative;
+	min-height: 100vh;
+	overflow: hidden;
+	background:
+		radial-gradient(circle at top left, rgba(47, 107, 255, 0.12), transparent 32%),
+		radial-gradient(circle at 85% 8%, rgba(198, 139, 89, 0.12), transparent 24%),
+		linear-gradient(180deg, #09111b 0%, #0d1724 20%, #f4f7fb 20.1%, #eef2f8 100%);
+}
+
+.mainContainer::before {
+	content: "";
+	position: fixed;
+	inset: 0;
+	pointer-events: none;
+	background-image:
+		linear-gradient(rgba(148, 163, 184, 0.08) 1px, transparent 1px),
+		linear-gradient(90deg, rgba(148, 163, 184, 0.08) 1px, transparent 1px);
+	background-size: 72px 72px;
+	mask-image: linear-gradient(180deg, rgba(0, 0, 0, 0.68), transparent 78%);
+}
+
+.content {
+	position: relative;
+	z-index: 1;
+}

--- a/components/layout/layout.tsx
+++ b/components/layout/layout.tsx
@@ -1,76 +1,57 @@
-// Libs
 import PropTypes from "prop-types";
 import Head from "next/head";
-import React, {ReactNode} from 'react';
-import { useEffect } from 'react';
-import { useRouter } from "next/router";
-import { AppProps } from 'next/app';
-// import { Analytics } from '@vercel/analytics/react';
-
-// Components
-import { HeaderCustom } from '../headerCustom';
-import { FooterCustom } from '../footerCustom';
-
-//CSS Module
+import React, { ReactNode } from "react";
+import { HeaderCustom } from "../headerCustom";
+import { FooterCustom } from "../footerCustom";
+import { PortfolioLocale } from "../../content/portfolioContent";
 import styles from "./layout.module.scss";
-import Image from "next/image";
 
 type LayoutProps = {
     children: ReactNode;
+    locale: PortfolioLocale;
     title?: string;
+    description?: string;
 };
 
-export function Layout ({
+export function Layout({
     children,
-    title = 'Développeur informatique .NET - Valentin PASSE'
-    } : LayoutProps) 
-{    
+    locale,
+    title = "Valentin PASSE | Freelance Fullstack .NET",
+    description = "Portfolio de Valentin PASSE, freelance Fullstack .NET.",
+}: LayoutProps) {
+    const ogLocale = locale === "en" ? "en_US" : "fr_FR";
+
     return (
-        <div className={styles["main-container"]}>
+        <div className={styles.mainContainer}>
             <Head>
                 <meta charSet="utf-8" />
-                <meta name="acharSet=thor" content="Valentin PASSE" />
                 <meta name="author" content="Valentin PASSE" />
                 <meta name="copyright" content="Portfolio of Valentin PASSE" />
-                <meta name="keywords" content="Valentin Passé, Valentin Passe, Portfolio, Web Developer, Développeur Web, Informatique, Web, .Net, C#, NextJS, Developer .Net, Backend, Frontend, freelance, autoentrepreneur" />
-                <meta name="description" content="Portfolio de Valentin PASSE. Développeur Web spécialisé dans la technologie Microsoft et les nouvelles technologies." />
+                <meta
+                    name="keywords"
+                    content="Valentin Passe, Portfolio, Fullstack .NET, Blazor, C#, Azure, freelance, software delivery"
+                />
+                <meta name="description" content={description} />
                 <meta name="viewport" content="width=device-width, initial-scale=1" />
-                <meta name="robots" content="Valentin Passé, Valentin Passe, Portfolio, Web Developer, Développeur Web, Web, Développeur informatique" />
-
-                <meta itemProp="name" content="Valentin PASSE - Portfolio professionnel - Développeur informatique" />
-                <meta itemProp="description" content="Porfolio de Valentin PASSE, développeur web en auto-entrepreneur." />
-                <meta itemProp="image" content="https://valentin-passe.com" />
-                
-                <meta property="og:title" content="Valentin PASSE - Portfolio professionnel - Développeur informatique" />
-                <meta property="og:description" content="Porfolio de Valentin PASSE, développeur web en auto-entrepreneur." />
-                <meta property="og:image" content="https://valentin-passe.com/assets/images/home/image1.webp" />
-                <meta property="og:url" content="https://valentin-passe.com" />
-                <meta property="og:site_name" content="Développeur .NET - Valentin PASSE" />
-                <meta property="og:locale" content="fr_FR" />
+                <meta name="robots" content="index,follow" />
+                <meta itemProp="name" content={title} />
+                <meta itemProp="description" content={description} />
+                <meta property="og:title" content={title} />
+                <meta property="og:description" content={description} />
+                <meta property="og:site_name" content="Valentin PASSE" />
+                <meta property="og:locale" content={ogLocale} />
                 <meta property="og:type" content="website" />
-
-                <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-                <meta name="robots" content="Valentin Passé, Valentin Passe, Portfolio, Web Developer, Développeur Web, Web" />
-                <meta name="author" content="Passé Valentin" />
-
                 <title>{title}</title>
                 <link rel="icon" href="/favicon.ico" />
             </Head>
 
-            <HeaderCustom />
-            <main>
-                {children}
-                {/* <Analytics /> */}
-            </main>
-
-            <FooterCustom />            
+            <HeaderCustom locale={locale} />
+            <div className={styles.content}>{children}</div>
+            <FooterCustom locale={locale} />
         </div>
-    )
+    );
 }
 
 Layout.propTypes = {
-    /**
-     * page content
-     */
     children: PropTypes.node.isRequired,
-}
+};

--- a/components/sectionContact/sectionContact.module.scss
+++ b/components/sectionContact/sectionContact.module.scss
@@ -1,26 +1,42 @@
 .section {
   width: 100%;
-  padding: 4rem 1.5rem;
-  background-color: #f8fafc;
+  padding: 6rem 1.5rem;
+  background:
+    radial-gradient(circle at 20% 16%, rgba(47, 107, 255, 0.16), transparent 24%),
+    radial-gradient(circle at 82% 14%, rgba(198, 139, 89, 0.14), transparent 20%),
+    linear-gradient(180deg, #09111b 0%, #0d1724 100%);
 }
 
 .container {
-  max-width: 900px;
+  max-width: 920px;
   margin: 0 auto;
   text-align: center;
+  padding: 2rem;
+  border-radius: 32px;
+  border: 1px solid rgba(148, 163, 184, 0.16);
+  background: rgba(9, 17, 27, 0.58);
+  box-shadow: 0 30px 80px rgba(2, 8, 23, 0.24);
 }
 
 .title {
   margin: 0;
-  font-size: clamp(1.8rem, 3vw, 2.4rem);
-  color: #0f172a;
+  font-family: var(--font-display);
+  font-size: clamp(2.2rem, 3vw, 3.2rem);
+  color: #f8fafc;
 }
 
 .description {
   margin: 1rem auto 0;
   max-width: 680px;
-  line-height: 1.6;
-  color: #334155;
+  line-height: 1.75;
+  color: rgba(226, 232, 240, 0.82);
+}
+
+.responsePromise {
+  margin: 0.8rem auto 0;
+  max-width: 620px;
+  color: #bfd7ff;
+  font-weight: 600;
 }
 
 .inquiryList {
@@ -28,12 +44,16 @@
   max-width: 680px;
   text-align: left;
   display: grid;
-  gap: 0.45rem;
-  color: #1f2937;
+  gap: 0.65rem;
+  color: #f8fafc;
 }
 
 .inquiryItem {
-  line-height: 1.55;
+  line-height: 1.6;
+  padding: 0.9rem 1rem;
+  border-radius: 18px;
+  border: 1px solid rgba(148, 163, 184, 0.16);
+  background: rgba(255, 255, 255, 0.05);
 }
 
 .actions {
@@ -49,8 +69,9 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  padding: 0.7rem 1.1rem;
-  border-radius: 8px;
+  min-height: 50px;
+  padding: 0.82rem 1.15rem;
+  border-radius: 999px;
   text-decoration: none;
   font-weight: 600;
   transition: transform 0.15s ease, opacity 0.15s ease;
@@ -58,36 +79,36 @@
 }
 
 .primaryAction {
-  background-color: #0f172a;
-  color: #ffffff;
+  background: linear-gradient(135deg, #dbeafe 0%, #bfdbfe 45%, #f5d0a9 100%);
+  color: #09111b;
 }
 
 .secondaryAction {
-  background-color: #ffffff;
-  color: #0f172a;
-  border: 1px solid #cbd5e1;
+	background-color: rgba(255, 255, 255, 0.08);
+	color: #f8fafc;
+	border: 1px solid rgba(148, 163, 184, 0.22);
 }
 
 .emailText {
   margin: 1rem 0 0;
-  color: #334155;
+  color: rgba(226, 232, 240, 0.78);
 }
 
 .emailText a {
-  color: #0f172a;
+  color: #f8fafc;
   font-weight: 600;
 }
 
 .meta {
   margin: 0.35rem 0 0;
-  color: #475569;
+	color: rgba(226, 232, 240, 0.6);
   font-size: 0.95rem;
 }
 
 .feedback {
   min-height: 1.2rem;
   margin: 0.7rem 0 0;
-  color: #0f766e;
+	color: #93c5fd;
   font-size: 0.9rem;
 }
 
@@ -99,7 +120,7 @@
 
 .primaryAction:focus-visible,
 .secondaryAction:focus-visible {
-  outline: 2px solid #0f172a;
+  outline: 2px solid #bfdbfe;
   outline-offset: 2px;
 }
 
@@ -117,7 +138,11 @@
 
 @media (max-width: 640px) {
   .section {
-    padding: 3.5rem 1rem;
+    padding: 4rem 1rem;
+  }
+
+  .container {
+    padding: 1.3rem;
   }
 
   .actions {

--- a/components/sectionContact/sectionContact.tsx
+++ b/components/sectionContact/sectionContact.tsx
@@ -1,28 +1,26 @@
 import React, { useState } from "react";
+import { PortfolioLocale, getPortfolioContent, portfolioEmail } from "../../content/portfolioContent";
 import styles from "./sectionContact.module.scss";
 
-const CONTACT_EMAIL = "passe.valentin@gmail.com";
+type SectionContactProps = {
+  locale?: PortfolioLocale;
+};
 
-const INQUIRY_TYPES = [
-  "Création ou refonte d'application web .NET",
-  "Renfort Fullstack sur produit existant",
-  "Audit technique et plan de delivery",
-];
-
-export function SectionContact() {
+export function SectionContact({ locale = "fr" }: SectionContactProps) {
+  const content = getPortfolioContent(locale).contact;
   const [feedback, setFeedback] = useState<string>("");
 
   const handleCopyEmail = async () => {
     if (typeof navigator === "undefined" || !navigator.clipboard) {
-      setFeedback("Copie non disponible. Utilisez l'adresse e-mail affichée ci-dessous.");
+      setFeedback(content.copyUnavailable);
       return;
     }
 
     try {
-      await navigator.clipboard.writeText(CONTACT_EMAIL);
-      setFeedback("Adresse e-mail copiée.");
+      await navigator.clipboard.writeText(portfolioEmail);
+      setFeedback(content.copySuccess);
     } catch {
-      setFeedback("Impossible de copier l'adresse automatiquement. Copiez-la manuellement.");
+      setFeedback(content.copyError);
     }
   };
 
@@ -30,16 +28,13 @@ export function SectionContact() {
     <section id="contact" className={styles.section} aria-labelledby="contact-title">
       <div className={styles.container}>
         <h2 id="contact-title" className={styles.title}>
-          Contact
+          {content.title}
         </h2>
-        <p className={styles.description}>
-          Dites-moi ce que vous souhaitez livrer et je vous réponds rapidement.
-          Je suis disponible pour des missions freelance .NET en remote, hybride
-          ou sur site.
-        </p>
+        <p className={styles.description}>{content.description}</p>
+        <p className={styles.responsePromise}>{content.responsePromise}</p>
 
         <ul className={styles.inquiryList} aria-label="Types de demandes">
-          {INQUIRY_TYPES.map((item) => (
+          {content.inquiryTypes.map((item) => (
             <li key={item} className={styles.inquiryItem}>
               {item}
             </li>
@@ -48,11 +43,11 @@ export function SectionContact() {
 
         <div className={styles.actions}>
           <a
-            href={`mailto:${CONTACT_EMAIL}`}
+            href={`mailto:${portfolioEmail}`}
             className={styles.primaryAction}
             aria-label="Envoyer un e-mail à Valentin Passe"
           >
-            Me contacter
+            {content.primaryActionLabel}
           </a>
 
           <button
@@ -61,14 +56,14 @@ export function SectionContact() {
             onClick={handleCopyEmail}
             aria-label="Copier l'adresse e-mail"
           >
-            Copier l'adresse e-mail
+            {content.copyActionLabel}
           </button>
         </div>
 
         <p className={styles.emailText}>
-          Email direct: <a href={`mailto:${CONTACT_EMAIL}`}>{CONTACT_EMAIL}</a>
+          {content.emailLabel}: <a href={`mailto:${portfolioEmail}`}>{portfolioEmail}</a>
         </p>
-        <p className={styles.meta}>Nice, Provence-Alpes-Côte d'Azur · LinkedIn disponible sur demande</p>
+        <p className={styles.meta}>{content.meta}</p>
         <p className={styles.feedback} role="status" aria-live="polite">
           {feedback}
         </p>

--- a/components/sectionEducations/sectionEducations.module.scss
+++ b/components/sectionEducations/sectionEducations.module.scss
@@ -1,0 +1,103 @@
+.section {
+	width: 100%;
+	padding: 5rem 1.25rem;
+	background: linear-gradient(180deg, #f7f9fc 0%, #ffffff 100%);
+}
+
+.container {
+	max-width: 1140px;
+	margin: 0 auto;
+}
+
+.header {
+	max-width: 760px;
+	margin-bottom: 2rem;
+}
+
+.title {
+	margin: 0;
+	color: #0f172a;
+	font-size: clamp(1.95rem, 2.5vw, 2.6rem);
+	letter-spacing: -0.02em;
+}
+
+.subtitle {
+	margin: 0.85rem 0 0;
+	color: #334155;
+	line-height: 1.65;
+	font-size: 1.02rem;
+}
+
+.grid {
+	display: grid;
+	grid-template-columns: repeat(2, minmax(0, 1fr));
+	gap: 1rem;
+}
+
+.card {
+	padding: 1.25rem;
+	border-radius: 18px;
+	border: 1px solid #d7e0f1;
+	background: #ffffff;
+	box-shadow: 0 10px 24px rgba(15, 23, 42, 0.06);
+}
+
+.period {
+	margin: 0;
+	color: #0f172a;
+	font-weight: 700;
+	font-size: 0.84rem;
+	letter-spacing: 0.08em;
+	text-transform: uppercase;
+}
+
+.cardTitle {
+	margin: 0.55rem 0 0;
+	color: #0f172a;
+	font-size: 1.1rem;
+}
+
+.institution {
+	margin: 0.25rem 0 0;
+	color: #334155;
+	font-weight: 600;
+}
+
+.description {
+	margin: 0.75rem 0 0;
+	color: #475569;
+	line-height: 1.65;
+}
+
+.continuousLearning {
+	margin-top: 1rem;
+	padding: 1.25rem;
+	border-radius: 18px;
+	background: #0f172a;
+	color: #f8fafc;
+}
+
+.continuousLearningLabel {
+	margin: 0;
+	font-size: 0.84rem;
+	font-weight: 700;
+	letter-spacing: 0.08em;
+	text-transform: uppercase;
+	color: #93c5fd;
+}
+
+.continuousLearningText {
+	margin: 0.7rem 0 0;
+	line-height: 1.7;
+	color: rgba(248, 250, 252, 0.88);
+}
+
+@media (max-width: 700px) {
+	.section {
+		padding: 3.5rem 1rem;
+	}
+
+	.grid {
+		grid-template-columns: 1fr;
+	}
+}

--- a/components/sectionEducations/sectionEducations.tsx
+++ b/components/sectionEducations/sectionEducations.tsx
@@ -1,316 +1,40 @@
-// Libs
-import React from 'react';
+﻿import React from "react";
+import { PortfolioLocale, getPortfolioContent } from "../../content/portfolioContent";
+import styles from "./sectionEducations.module.scss";
 
-// Images
+type SectionEducationsProps = {
+  locale?: PortfolioLocale;
+};
 
-// CSS Module
-import styles from "./sectionEducations.module.scss"
-
-// Data
-// import skillsData from "../../public/data/skills.json";
-
-export function SectionEducations () {
-//   interface Skill {
-//     label: string;
-//     description: string;
-//     category: SkillCategory;
-//     position: number;
-//   }
-
-//   enum SkillCategory {
-//     Technlology = "Technologie Microsoft",
-//     Database = "Base de donnée",
-//     Other = "Autre",
-//     Software = "Logiciel",
-//     OperatingSystem = "Système d'exploitation",
-//     Qualification = "Compétence"
-//   }
-
-//   const skills = skillsData; // converrt to skill
+export function SectionEducations({ locale = "fr" }: SectionEducationsProps) {
+  const content = getPortfolioContent(locale).education;
 
   return (
-    <section id="educations" className="content-section text-center">
-        {/* <div className="skills-section">
-            <div className="skills-container">
-                <h2>Skills</h2>
-                <div className="row pr-2">
-                    <div className="col-md-4 col-sm-6 col-xs-12">
-                        <div className="bloc-title-skills">
-                            <div className="title-skills"><span className="label label-primary">Technology</span></div>
-                        </div>
-                        <span className="label-progress">Microsoft .NET</span>
-                        <div className="progress">
-                            <div className="progress-bar progress-bar-striped active" role="progressbar" aria-valuenow="90" aria-valuemin="0" aria-valuemax="100" style="width: 90%">
-                                90%
-                                <span className="sr-only">90% Complete</span>
-                            </div>
-                        </div>
-                        <span className="label-progress">AJAX</span>
-                        <div className="progress">
-                            <div className="progress-bar progress-bar-striped active" role="progressbar" aria-valuenow="90" aria-valuemin="0" aria-valuemax="100" style="width: 90%">
-                                90%
-                                <span className="sr-only">90% Complete</span>
-                            </div>
-                        </div>
-                        <span className="label-progress">SSIS</span>
-                        <div className="progress">
-                            <div className="progress-bar progress-bar-striped active" role="progressbar" aria-valuenow="90" aria-valuemin="0" aria-valuemax="100" style="width: 90%">
-                                70%
-                                <span className="sr-only">90% Complete</span>
-                            </div>
-                        </div>
-                        <div className="bloc-title-skills">
-                            <div className="title-skills"><span className="label label-primary">language</span></div>
-                        </div>
-                        <span className="label-progress">HTML5</span>
-                        <div className="progress">
-                            <div className="progress-bar progress-bar-striped active" role="progressbar" aria-valuenow="95" aria-valuemin="0" aria-valuemax="100" style="width: 95%">
-                                95%
-                                <span className="sr-only">95% Complete</span>
-                            </div>
-                        </div>
-                        <span className="label-progress">CSS3</span>
-                        <div className="progress">
-                            <div className="progress-bar progress-bar-striped active" role="progressbar" aria-valuenow="95" aria-valuemin="0" aria-valuemax="100" style="width: 95%">
-                                95%
-                                <span className="sr-only">95% Complete</span>
-                            </div>
-                        </div>
-                        <span className="label-progress">JavaScript</span>
-                        <div className="progress">
-                            <div className="progress-bar progress-bar-striped active" role="progressbar" aria-valuenow="85" aria-valuemin="0" aria-valuemax="100" style="width: 85%">
-                                85%
-                                <span className="sr-only">85% Complete</span>
-                            </div>
-                        </div>
-                        <span className="label-progress">PHP</span>
-                        <div className="progress">
-                            <div className="progress-bar progress-bar-striped active" role="progressbar" aria-valuenow="60" aria-valuemin="0" aria-valuemax="100" style="width: 60%">
-                                60%
-                                <span className="sr-only">60% Complete</span>
-                            </div>
-                        </div>
-                        <span className="label-progress">ASP.NET</span>
-                        <div className="progress">
-                            <div className="progress-bar progress-bar-striped active" role="progressbar" aria-valuenow="90" aria-valuemin="0" aria-valuemax="100" style="width: 90%">
-                                90%
-                                <span className="sr-only">90% Complete</span>
-                            </div>
-                        </div>
-                        <span className="label-progress">SQL</span>
-                        <div className="progress">
-                            <div className="progress-bar progress-bar-striped active" role="progressbar" aria-valuenow="95" aria-valuemin="0" aria-valuemax="100" style="width: 95%">
-                                95%
-                                <span className="sr-only">95% Complete</span>
-                            </div>
-                        </div>
-                        <span className="label-progress">C#</span>
-                        <div className="progress">
-                            <div className="progress-bar progress-bar-striped active" role="progressbar" aria-valuenow="90" aria-valuemin="0" aria-valuemax="100" style="width: 90%">
-                                90%
-                                <span className="sr-only">90% Complete</span>
-                            </div>
-                        </div>
-                        <span className="label-progress">Java</span>
-                        <div className="progress">
-                            <div className="progress-bar progress-bar-striped active" role="progressbar" aria-valuenow="50" aria-valuemin="0" aria-valuemax="100" style="width: 50%">
-                                50%
-                                <span className="sr-only">50% Complete</span>
-                            </div>
-                        </div>
-                        <span className="label-progress">XML</span>
-                        <div className="progress">
-                            <div className="progress-bar progress-bar-striped active" role="progressbar" aria-valuenow="95" aria-valuemin="0" aria-valuemax="100" style="width: 95%">
-                                95%
-                                <span className="sr-only">95% Complete</span>
-                            </div>
-                        </div>
-                        <span className="label-progress">JSON</span>
-                        <div className="progress">
-                            <div className="progress-bar progress-bar-striped active" role="progressbar" aria-valuenow="95" aria-valuemin="0" aria-valuemax="100" style="width: 95%">
-                                95%
-                                <span className="sr-only">95% Complete</span>
-                            </div>
-                        </div>
-    
-                    </div>
-                    <div className="col-md-4 col-sm-6 col-xs-12">
-                        <div className="bloc-title-skills">
-                            <div className="title-skills"><span className="label label-info">Operating systems</span></div>
-                        </div>
-                        <span className="label-progress">Windows XP, Vista, 7, 8, 10</span>
-                        <div className="progress">
-                            <div className="progress-bar progress-bar-info progress-bar-striped active" role="progressbar" aria-valuenow="90" aria-valuemin="0" aria-valuemax="100" style="width: 90%">
-                                90%
-                                <span className="sr-only">90% Complete</span>
-                            </div>
-                        </div>
-                        <span className="label-progress">Mac OS X</span>
-                        <div className="progress">
-                            <div className="progress-bar progress-bar-info progress-bar-striped active" role="progressbar" aria-valuenow="75" aria-valuemin="0" aria-valuemax="100" style="width: 75%">
-                                75%
-                                <span className="sr-only">75% Complete</span>
-                            </div>
-                        </div>
-                        <span className="label-progress">Linux</span>
-                        <div className="progress">
-                            <div className="progress-bar progress-bar-info progress-bar-striped active" role="progressbar" aria-valuenow="50" aria-valuemin="0" aria-valuemax="100" style="width: 50%">
-                                50%
-                                <span className="sr-only">50% Complete</span>
-                            </div>
-                        </div>
-                        <div className="bloc-title-skills">
-                            <div className="title-skills"><span className="label label-danger">Database</span></div>
-                        </div>
-                        <span className="label-progress">SQL server</span>
-                        <div className="progress">
-                            <div className="progress-bar progress-bar-danger progress-bar-striped active" role="progressbar" aria-valuenow="90" aria-valuemin="0" aria-valuemax="100" style="width: 90%">
-                                90%
-                                <span className="sr-only">90% Complete</span>
-                            </div>
-                        </div>
-                        <span className="label-progress">Oracle</span>
-                        <div className="progress">
-                            <div className="progress-bar progress-bar-danger progress-bar-striped active" role="progressbar" aria-valuenow="70" aria-valuemin="0" aria-valuemax="100" style="width: 70%">
-                                70%
-                                <span className="sr-only">70% Complete (warning)</span>
-                            </div>
-                        </div>
-                        <span className="label-progress">MySQL</span>
-                        <div className="progress">
-                            <div className="progress-bar progress-bar-danger progress-bar-striped active" role="progressbar" aria-valuenow="80" aria-valuemin="0" aria-valuemax="100" style="width: 80%">
-                                80%
-                                <span className="sr-only">80% Complete</span>
-                            </div>
-                        </div>
-                        <div className="bloc-title-skills">
-                            <div className="title-skills"><span className="label label-warning">IDE &amp; Text Editor</span></div>
-                        </div>
-                        <span className="label-progress">VS 2010, 2012, 2013</span>
-                        <div className="progress">
-                            <div className="progress-bar progress-bar-warning progress-bar-striped active" role="progressbar" aria-valuenow="90" aria-valuemin="0" aria-valuemax="100" style="width: 90%">
-                                90%
-                                <span className="sr-only">90% Complete</span>
-                            </div>
-                        </div>
-                        <span className="label-progress">Adobe Dreamweaver</span>
-                        <div className="progress">
-                            <div className="progress-bar progress-bar-warning progress-bar-striped active" role="progressbar" aria-valuenow="70" aria-valuemin="0" aria-valuemax="100" style="width: 70%">
-                                70%
-                                <span className="sr-only">70% Complete</span>
-                            </div>
-                        </div>
-                        <span className="label-progress">PhpStorm</span>
-                        <div className="progress">
-                            <div className="progress-bar progress-bar-warning progress-bar-striped active" role="progressbar" aria-valuenow="60" aria-valuemin="0" aria-valuemax="100" style="width: 60%">
-                                60%
-                                <span className="sr-only">60% Complete</span>
-                            </div>
-                        </div>
-                        <span className="label-progress">Eclipse</span>
-                        <div className="progress">
-                            <div className="progress-bar progress-bar-warning progress-bar-striped active" role="progressbar" aria-valuenow="60" aria-valuemin="0" aria-valuemax="100" style="width: 60%">
-                                60%
-                                <span className="sr-only">60% Complete</span>
-                            </div>
-                        </div>
-                        <span className="label-progress">Sublime Text 2</span>
-                        <div className="progress">
-                            <div className="progress-bar progress-bar-warning progress-bar-striped active" role="progressbar" aria-valuenow="85" aria-valuemin="0" aria-valuemax="100" style="width: 85%">
-                                85%
-                                <span className="sr-only">85% Complete</span>
-                            </div>
-                        </div>
-                        <span className="label-progress">Notepad ++</span>
-                        <div className="progress">
-                            <div className="progress-bar progress-bar-warning progress-bar-striped active" role="progressbar" aria-valuenow="90" aria-valuemin="0" aria-valuemax="100" style="width: 90%">
-                                90%
-                                <span className="sr-only">90% Complete</span>
-                            </div>
-                        </div>
-                    <div className="col-md-4 col-sm-6 col-xs-12">
-                        <!-- Bloc Office software -->
-                        <div className="bloc-title-skills">
-                            <div className="title-skills"><span className="label label-success">Office software</span></div>
-                        </div>
-                        <span className="label-progress">Team Foundation Server (TFS)</span>
-                        <div className="progress">
-                            <div className="progress-bar progress-bar-success progress-bar-striped active" role="progressbar" aria-valuenow="85" aria-valuemin="0" aria-valuemax="100" style="width: 85%">
-                                85%
-                                <span className="sr-only">85% Complete</span>
-                            </div>
-                        </div>
-                        <span className="label-progress">Microsoft Office</span>
-                        <div className="progress">
-                            <div className="progress-bar progress-bar-success progress-bar-striped active" role="progressbar" aria-valuenow="90" aria-valuemin="0" aria-valuemax="100" style="width: 90%">
-                                90%
-                                <span className="sr-only">90% Complete</span>
-                            </div>
-                        </div>
-                        <span className="label-progress">iWorks (Mac)</span>
-                        <div className="progress">
-                            <div className="progress-bar progress-bar-success progress-bar-striped active" role="progressbar" aria-valuenow="90" aria-valuemin="0" aria-valuemax="100" style="width: 90%">
-                                90%
-                                <span className="sr-only">90% Complete</span>
-                            </div>
-                        </div>
-                        <span className="label-progress">Adobe Photoshop</span>
-                        <div className="progress">
-                            <div className="progress-bar progress-bar-success progress-bar-striped active" role="progressbar" aria-valuenow="80" aria-valuemin="0" aria-valuemax="100" style="width: 80%">
-                                80%
-                                <span className="sr-only">80% Complete</span>
-                            </div>
-                        </div>
-                        <span className="label-progress">Adobe InDesign</span>
-                        <div className="progress">
-                            <div className="progress-bar progress-bar-success progress-bar-striped active" role="progressbar" aria-valuenow="70" aria-valuemin="0" aria-valuemax="100" style="width: 70%">
-                                70%
-                                <span className="sr-only">70% Complete</span>
-                            </div>
-                        </div>
-                        <div className="bloc-title-skills">
-                            <div className="title-skills"><span className="label label-grey">qualifications</span></div>
-                        </div>
-                        <span className="label-progress">team spirit</span>
-                        <div className="progress">
-                            <div className="progress-bar progress-bar-grey progress-bar-striped active" role="progressbar" aria-valuenow="95" aria-valuemin="0" aria-valuemax="100" style="width: 95%">
-                                95%
-                                <span className="sr-only">95% Complete</span>
-                            </div>
-                        </div>
-                        <span className="label-progress">self-educated</span>
-                        <div className="progress">
-                            <div className="progress-bar progress-bar-grey progress-bar-striped active" role="progressbar" aria-valuenow="95" aria-valuemin="0" aria-valuemax="100" style="width: 95%">
-                                95%
-                                <span className="sr-only">95% Complete</span>
-                            </div>
-                        </div>
-                        <span className="label-progress">dynamic</span>
-                        <div className="progress">
-                            <div className="progress-bar progress-bar-grey progress-bar-striped active" role="progressbar" aria-valuenow="95" aria-valuemin="0" aria-valuemax="100" style="width: 95%">
-                                95%
-                                <span className="sr-only">95% Complete</span>
-                            </div>
-                        </div>
-                        <span className="label-progress">methodical</span>
-                        <div className="progress">
-                            <div className="progress-bar progress-bar-grey progress-bar-striped active" role="progressbar" aria-valuenow="95" aria-valuemin="0" aria-valuemax="100" style="width: 95%">
-                                95%
-                                <span className="sr-only">95% Complete</span>
-                            </div>
-                        </div>
-                        <span className="label-progress">autonomous</span>
-                        <div className="progress">
-                            <div className="progress-bar progress-bar-grey progress-bar-striped active" role="progressbar" aria-valuenow="95" aria-valuemin="0" aria-valuemax="100" style="width: 95%">
-                                95%
-                                <span className="sr-only">95% Complete</span>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-    
-            </div>
-        </div> */}
+    <section id="educations" className={styles.section} aria-labelledby="educations-title">
+      <div className={styles.container}>
+        <header className={styles.header}>
+          <h2 id="educations-title" className={styles.title}>
+            {content.title}
+          </h2>
+          <p className={styles.subtitle}>{content.subtitle}</p>
+        </header>
+
+        <div className={styles.grid}>
+          {content.entries.map((entry) => (
+            <article key={`${entry.period}-${entry.title}`} className={styles.card}>
+              <p className={styles.period}>{entry.period}</p>
+              <h3 className={styles.cardTitle}>{entry.title}</h3>
+              <p className={styles.institution}>{entry.institution}</p>
+              <p className={styles.description}>{entry.description}</p>
+            </article>
+          ))}
+        </div>
+
+        <aside className={styles.continuousLearning} aria-label={content.continuousLearningTitle}>
+          <p className={styles.continuousLearningLabel}>{content.continuousLearningTitle}</p>
+          <p className={styles.continuousLearningText}>{content.continuousLearningText}</p>
+        </aside>
+      </div>
     </section>
   );
 }

--- a/components/sectionProjects/sectionProjects.module.scss
+++ b/components/sectionProjects/sectionProjects.module.scss
@@ -1,9 +1,9 @@
 .section {
 	width: 100%;
-	padding: 5rem 1.25rem;
+	padding: 6rem 1.25rem;
 	background:
-		linear-gradient(180deg, #f8fafc 0%, #ffffff 100%),
-		radial-gradient(circle at 80% 10%, rgba(14, 165, 233, 0.06) 0%, transparent 42%);
+		radial-gradient(circle at 14% 10%, rgba(47, 107, 255, 0.08), transparent 24%),
+		linear-gradient(180deg, #f2f6fb 0%, #ffffff 100%);
 }
 
 .container {
@@ -19,8 +19,9 @@
 .title {
 	margin: 0;
 	color: #0f172a;
-	font-size: clamp(1.95rem, 2.5vw, 2.6rem);
-	letter-spacing: -0.02em;
+	font-family: var(--font-display);
+	font-size: clamp(2.2rem, 3vw, 3.2rem);
+	letter-spacing: -0.03em;
 }
 
 .subtitle {
@@ -33,24 +34,32 @@
 .grid {
 	display: grid;
 	grid-template-columns: repeat(3, minmax(0, 1fr));
-	gap: 1rem;
+	gap: 1.15rem;
 }
 
 .card {
 	display: flex;
 	flex-direction: column;
-	gap: 0.55rem;
-	border: 1px solid #dbe3f1;
-	border-radius: 16px;
-	background: #ffffff;
-	box-shadow: 0 10px 24px rgba(15, 23, 42, 0.06);
-	padding: 1rem;
+	gap: 0.6rem;
+	border: 1px solid rgba(148, 163, 184, 0.18);
+	border-radius: 24px;
+	background: rgba(255, 255, 255, 0.92);
+	box-shadow: 0 18px 44px rgba(15, 23, 42, 0.06);
+	padding: 1.2rem;
+}
+
+.card::before {
+	content: "";
+	width: 72px;
+	height: 4px;
+	border-radius: 999px;
+	background: linear-gradient(90deg, #2f6bff 0%, #c68b59 100%);
 }
 
 .cardTitle {
 	margin: 0;
 	color: #0f172a;
-	font-size: 1.03rem;
+	font-size: 1.12rem;
 }
 
 .summary {
@@ -86,7 +95,7 @@
 
 .tag {
 	border-radius: 999px;
-	border: 1px solid #d7e0ee;
+	border: 1px solid rgba(148, 163, 184, 0.18);
 	background: #f8fbff;
 	color: #1e293b;
 	padding: 0.24rem 0.58rem;
@@ -112,21 +121,22 @@
 	display: inline-flex;
 	align-items: center;
 	justify-content: center;
-	border-radius: 10px;
+	min-height: 50px;
+	border-radius: 999px;
 	font-weight: 600;
 	text-decoration: none;
-	padding: 0.66rem 0.95rem;
+	padding: 0.75rem 1rem;
 }
 
 .primaryCta {
-	background: #0f172a;
-	color: #ffffff;
+	background: linear-gradient(135deg, #dbeafe 0%, #bfdbfe 45%, #f5d0a9 100%);
+	color: #09111b;
 }
 
 .secondaryCta {
-	background: #ffffff;
+	background: rgba(255, 255, 255, 0.88);
 	color: #0f172a;
-	border: 1px solid #cbd5e1;
+	border: 1px solid rgba(148, 163, 184, 0.24);
 }
 
 @media (max-width: 1024px) {

--- a/components/sectionProjects/sectionProjects.tsx
+++ b/components/sectionProjects/sectionProjects.tsx
@@ -107,7 +107,7 @@ export function SectionProjects() {
             Discuter de votre projet
           </a>
           <a href="#contact" className={styles.secondaryCta}>
-            Demander le CV
+            Demander un echange
           </a>
         </div>
       </div>

--- a/components/sectionProjects/sectionProjects.tsx
+++ b/components/sectionProjects/sectionProjects.tsx
@@ -1,71 +1,26 @@
 import React from "react";
+import { PortfolioLocale, getPortfolioContent } from "../../content/portfolioContent";
 import styles from "./sectionProjects.module.scss";
 
-type ProjectEntry = {
-  title: string;
-  summary: string;
-  context: string;
-  contribution: string;
-  outcome: string;
-  tags: string[];
-  publicLink?: string;
+type SectionProjectsProps = {
+  locale?: PortfolioLocale;
 };
 
-const PROJECTS: ProjectEntry[] = [
-  {
-    title: "Astreinte et interventions (SMEG)",
-    summary:
-      "Solution métier pour piloter appels d'astreinte, urgences et interventions sur usages bureau et mobile.",
-    context:
-      "Environnement opérationnel exigeant, avec contraintes de disponibilité et qualité de service continue.",
-    contribution:
-      "Conception et développement Fullstack sur socle .NET 7 / ABP, avec architecture orientée domaine.",
-    outcome:
-      "Digitalisation des processus terrain et meilleure réactivité des équipes dans les situations critiques.",
-    tags: [".NET", "C#", "ABP", "DDD", "Azure", "MongoDB"],
-  },
-  {
-    title: "Plateforme backend avec composante IA (TidyUp)",
-    summary:
-      "Base applicative pour le rangement, classement et la recherche de contenus numériques à forte valeur.",
-    context:
-      "Besoin d'une fondation backend robuste pour supporter l'évolution des fonctionnalités IA dans le temps.",
-    contribution:
-      "Développement backend en .NET MVC / .NET Core, structuration des flux techniques et de la persistance.",
-    outcome:
-      "Socle technique pérenne facilitant la montée en capacité produit et la fiabilité des traitements.",
-    tags: [".NET MVC", ".NET Core", "C#", "SQL", "Architecture"],
-  },
-  {
-    title: "Applications internes d'entreprise",
-    summary:
-      "Plusieurs projets internes menés sur des cycles longs pour soutenir les besoins métiers quotidiens.",
-    context:
-      "Contexte multi-applications avec enjeux de maintenabilité, performance et évolution progressive.",
-    contribution:
-      "Développement backend/fullstack, maintenance évolutive et amélioration continue de la qualité de delivery.",
-    outcome:
-      "Fiabilisation des processus internes et meilleure continuité de service pour les utilisateurs métiers.",
-    tags: [".NET", "Blazor", "Entity Framework", "SQL Server", "Delivery"],
-    publicLink: "https://c8g.fr",
-  },
-];
+export function SectionProjects({ locale = "fr" }: SectionProjectsProps) {
+  const content = getPortfolioContent(locale).projects;
 
-export function SectionProjects() {
   return (
     <section id="projects" className={styles.section} aria-labelledby="projects-title">
       <div className={styles.container}>
         <header className={styles.header}>
           <h2 id="projects-title" className={styles.title}>
-            Projets
+            {content.title}
           </h2>
-          <p className={styles.subtitle}>
-            Des cas concrets qui montrent comment je transforme un contexte métier en livraison utile.
-          </p>
+          <p className={styles.subtitle}>{content.subtitle}</p>
         </header>
 
         <div className={styles.grid}>
-          {PROJECTS.map((project) => (
+          {content.items.map((project) => (
             <article key={project.title} className={styles.card}>
               <h3 className={styles.cardTitle}>{project.title}</h3>
               <p className={styles.summary}>{project.summary}</p>
@@ -95,7 +50,7 @@ export function SectionProjects() {
                   rel="noopener noreferrer"
                   aria-label={`Voir le site de ${project.title} (lien externe)`}
                 >
-                  Voir un lien public
+                  {locale === "fr" ? "Voir un lien public" : "View public link"}
                 </a>
               ) : null}
             </article>
@@ -104,10 +59,10 @@ export function SectionProjects() {
 
         <div className={styles.ctaRow}>
           <a href="#contact" className={styles.primaryCta}>
-            Discuter de votre projet
+            {content.primaryAction.label}
           </a>
           <a href="#contact" className={styles.secondaryCta}>
-            Demander un echange
+            {content.secondaryAction.label}
           </a>
         </div>
       </div>

--- a/components/sectionResume/sectionResume.module.scss
+++ b/components/sectionResume/sectionResume.module.scss
@@ -1,14 +1,16 @@
 .section {
-  padding: 5rem 1.5rem;
-  background: linear-gradient(180deg, #ffffff 0%, #f6f8fc 100%);
+  padding: 6rem 1.5rem;
+  background:
+    radial-gradient(circle at 10% 18%, rgba(47, 107, 255, 0.08), transparent 24%),
+    linear-gradient(180deg, #f4f7fb 0%, #edf2f8 100%);
 }
 
 .container {
   max-width: 1120px;
   margin: 0 auto;
   display: grid;
-  grid-template-columns: 280px 1fr;
-  gap: 2.25rem;
+  grid-template-columns: 320px 1fr;
+  gap: 2.5rem;
   align-items: start;
 }
 
@@ -18,11 +20,11 @@
 }
 
 .portraitFrame {
-  background: radial-gradient(circle at 35% 20%, #f1f5ff, #dce7ff);
-  border: 1px solid #d6def4;
-  border-radius: 20px;
+  background: linear-gradient(180deg, #ffffff 0%, #eff4fb 100%);
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  border-radius: 28px;
   padding: 1rem;
-  box-shadow: 0 16px 40px rgba(15, 31, 70, 0.12);
+  box-shadow: 0 20px 50px rgba(15, 31, 70, 0.12);
 }
 
 .portrait {
@@ -35,28 +37,30 @@
 .contentColumn {
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  gap: 1.2rem;
 }
 
 .title {
   margin: 0;
-  font-size: clamp(1.75rem, 2.2vw, 2.4rem);
+  font-family: var(--font-display);
+  font-size: clamp(2.3rem, 3vw, 3.4rem);
   color: #0f1728;
+  letter-spacing: -0.03em;
 }
 
 .lead {
   margin: 0;
-  font-size: clamp(1.05rem, 1.2vw, 1.2rem);
-  line-height: 1.65;
-  color: #1f2a44;
+  font-size: clamp(1.08rem, 1.3vw, 1.28rem);
+  line-height: 1.75;
+  color: #22324b;
   max-width: 65ch;
 }
 
 .summary {
   display: grid;
   gap: 0.9rem;
-  color: #32415f;
-  line-height: 1.7;
+  color: #445266;
+  line-height: 1.78;
   max-width: 72ch;
 }
 
@@ -64,10 +68,32 @@
   margin: 0;
 }
 
+.principles {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.7rem;
+}
+
+.principleChip {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 38px;
+  padding: 0.55rem 0.9rem;
+  border-radius: 999px;
+  background: rgba(9, 17, 27, 0.94);
+  color: #f8fafc;
+  font-size: 0.82rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
 .highlightsTitle {
   margin: 0.8rem 0 0;
-  font-size: 1.2rem;
-  color: #17223b;
+  font-size: 1rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: #40618c;
 }
 
 .highlightsList {
@@ -76,20 +102,21 @@
   padding: 0;
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 0.9rem;
+  gap: 1rem;
 }
 
 .highlightCard {
-  background: #ffffff;
-  border: 1px solid #d7e0f4;
-  border-radius: 14px;
-  padding: 1rem;
-  min-height: 140px;
+  background: rgba(255, 255, 255, 0.9);
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  border-radius: 22px;
+  padding: 1.15rem;
+  min-height: 150px;
+  box-shadow: 0 18px 36px rgba(15, 23, 42, 0.06);
 }
 
 .highlightCard h4 {
   margin: 0;
-  font-size: 0.98rem;
+  font-size: 1rem;
   color: #0f2246;
 }
 
@@ -112,23 +139,24 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  padding: 0.7rem 1rem;
-  border-radius: 10px;
+  min-height: 50px;
+  padding: 0.82rem 1.1rem;
+  border-radius: 999px;
   font-weight: 600;
   text-decoration: none;
   transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 
 .primaryAction {
-  color: #ffffff;
-  background: #0f2f66;
-  border: 1px solid #0f2f66;
+  color: #09111b;
+  background: linear-gradient(135deg, #dbeafe 0%, #bfdbfe 45%, #f5d0a9 100%);
+  border: 1px solid transparent;
 }
 
 .secondaryAction {
   color: #0f2f66;
-  background: #ffffff;
-  border: 1px solid #9db0da;
+  background: rgba(255, 255, 255, 0.85);
+  border: 1px solid rgba(148, 163, 184, 0.26);
 }
 
 .primaryAction:hover,

--- a/components/sectionResume/sectionResume.tsx
+++ b/components/sectionResume/sectionResume.tsx
@@ -2,33 +2,17 @@ import React from "react";
 import Image from "next/image";
 
 import Profile from "../../public/images/resume/valentin-passe.webp";
+import { PortfolioLocale, getPortfolioContent } from "../../content/portfolioContent";
 
 import styles from "./sectionResume.module.scss";
 
-type Highlight = {
-  title: string;
-  description: string;
+type SectionResumeProps = {
+  locale?: PortfolioLocale;
 };
 
-const highlights: Highlight[] = [
-  {
-    title: "Livraison end-to-end",
-    description:
-      "Du cadrage métier au delivery, je pilote des applications web robustes, lisibles et orientées impact.",
-  },
-  {
-    title: "Polyvalence Fullstack .NET",
-    description:
-      "Je relie back-end .NET, front-end Blazor et architecture API pour accélérer la mise en production.",
-  },
-  {
-    title: "Vision produit & métier",
-    description:
-      "Je transforme des besoins business en solutions lisibles, maintenables et utiles pour vos utilisateurs finaux.",
-  },
-];
+export function SectionResume({ locale = "fr" }: SectionResumeProps) {
+  const content = getPortfolioContent(locale).about;
 
-export function SectionResume() {
   return (
     <section id="about" className={styles.section} aria-labelledby="about-title">
       <div className={styles.container}>
@@ -46,31 +30,29 @@ export function SectionResume() {
 
         <div className={styles.contentColumn}>
           <h2 id="about-title" className={styles.title}>
-            À propos
+            {content.title}
           </h2>
-          <p className={styles.lead}>
-            Ingénieur Fullstack .NET freelance, j&apos;accompagne les entreprises
-            qui veulent livrer plus vite des produits web fiables, lisibles et
-            orientés impact.
-          </p>
+          <p className={styles.lead}>{content.lead}</p>
 
           <div className={styles.summary}>
-            <p>
-              J&apos;interviens sur l&apos;ensemble de la chaîne de valeur : conception,
-              implémentation, qualité et mise en production. Mon objectif est
-              de proposer une exécution claire, sans dette inutile, avec une
-              vraie logique de résultat.
-            </p>
-            <p>
-              Mon approche combine rigueur technique, communication directe et
-              intégration IA pragmatique aux workflows pour booster l&apos;efficacité des équipes,
-              sans complexifier l&apos;expérience utilisateur.
-            </p>
+            {content.paragraphs.map((paragraph) => (
+              <p key={paragraph}>{paragraph}</p>
+            ))}
           </div>
 
-          <h3 className={styles.highlightsTitle}>Pourquoi collaborer avec moi</h3>
+          <div className={styles.principles} aria-label="Principes de travail">
+            {content.principles.map((item) => (
+              <span key={item} className={styles.principleChip}>
+                {item}
+              </span>
+            ))}
+          </div>
+
+          <h3 className={styles.highlightsTitle}>
+            {locale === "fr" ? "Pourquoi collaborer avec moi" : "Why work with me"}
+          </h3>
           <ul className={styles.highlightsList}>
-            {highlights.map((item) => (
+            {content.highlights.map((item) => (
               <li key={item.title} className={styles.highlightCard}>
                 <h4>{item.title}</h4>
                 <p>{item.description}</p>
@@ -80,10 +62,10 @@ export function SectionResume() {
 
           <div className={styles.actions}>
             <a href="#projects" className={styles.primaryAction}>
-              Voir mes projets
+              {content.primaryAction.label}
             </a>
             <a href="#contact" className={styles.secondaryAction}>
-              Me contacter
+              {content.secondaryAction.label}
             </a>
           </div>
         </div>

--- a/components/sectionServices/sectionServices.module.scss
+++ b/components/sectionServices/sectionServices.module.scss
@@ -1,9 +1,9 @@
 .section {
   width: 100%;
-  padding: 5rem 1.25rem;
+  padding: 6rem 1.25rem;
   background:
-    linear-gradient(160deg, rgba(15, 23, 42, 0.02) 0%, rgba(226, 232, 240, 0.45) 100%),
-    #ffffff;
+    radial-gradient(circle at 15% 10%, rgba(47, 107, 255, 0.08), transparent 24%),
+    linear-gradient(180deg, #eef3f9 0%, #f7f9fc 100%);
 }
 
 .container {
@@ -13,14 +13,15 @@
 
 .header {
   max-width: 760px;
-  margin-bottom: 2rem;
+  margin-bottom: 2.3rem;
 }
 
 .title {
   margin: 0;
   color: #0f172a;
-  font-size: clamp(1.95rem, 2.5vw, 2.6rem);
-  letter-spacing: -0.02em;
+  font-family: var(--font-display);
+  font-size: clamp(2.2rem, 3vw, 3.2rem);
+  letter-spacing: -0.03em;
 }
 
 .subtitle {
@@ -33,20 +34,28 @@
 .grid {
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 1rem;
+  gap: 1.15rem;
 }
 
 .card {
   position: relative;
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
-  padding: 1.1rem;
-  border-radius: 18px;
-  border: 1px solid #d8e2f0;
-  background: #f8fbff;
-  box-shadow: 0 10px 24px rgba(15, 23, 42, 0.07);
+  gap: 0.9rem;
+  padding: 1.35rem;
+  border-radius: 24px;
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  background: rgba(255, 255, 255, 0.88);
+  box-shadow: 0 18px 44px rgba(15, 23, 42, 0.07);
   animation: reveal 0.45s ease both;
+}
+
+.card::before {
+  content: "";
+  width: 72px;
+  height: 4px;
+  border-radius: 999px;
+  background: linear-gradient(90deg, #2f6bff 0%, #c68b59 100%);
 }
 
 .card:nth-child(2) {
@@ -60,12 +69,12 @@
 .cardTitle {
   margin: 0;
   color: #0f172a;
-  font-size: 1.05rem;
+  font-size: 1.12rem;
 }
 
 .block {
-  border-left: 3px solid #0ea5e9;
-  padding-left: 0.55rem;
+  border-left: 3px solid rgba(47, 107, 255, 0.4);
+  padding-left: 0.7rem;
 }
 
 .blockLabel {
@@ -86,10 +95,10 @@
 
 .capabilities {
   margin: 0;
-  padding-left: 1.1rem;
+  padding-left: 1rem;
   color: #1e293b;
   display: grid;
-  gap: 0.32rem;
+  gap: 0.42rem;
 }
 
 .capabilities li {
@@ -101,12 +110,13 @@
   display: inline-flex;
   justify-content: center;
   align-items: center;
-  border-radius: 10px;
+  min-height: 48px;
+  border-radius: 999px;
   background: #0f172a;
   color: #ffffff;
   text-decoration: none;
   font-weight: 600;
-  padding: 0.62rem 0.9rem;
+  padding: 0.72rem 0.95rem;
   transition: transform 0.16s ease, opacity 0.16s ease;
 }
 
@@ -144,7 +154,7 @@
 
 @media (max-width: 700px) {
   .section {
-    padding: 3.5rem 1rem;
+    padding: 4.2rem 1rem;
   }
 
   .grid {

--- a/components/sectionServices/sectionServices.tsx
+++ b/components/sectionServices/sectionServices.tsx
@@ -1,22 +1,23 @@
 import React from "react";
+import { PortfolioLocale, getPortfolioContent } from "../../content/portfolioContent";
 import styles from "./sectionServices.module.scss";
-import servicesData from "../../public/data/services.json";
-import { sanitizeServices } from "./sectionServices.extensions";
 
-export function SectionServices() {
-  const services = sanitizeServices(servicesData);
+type SectionServicesProps = {
+  locale?: PortfolioLocale;
+};
+
+export function SectionServices({ locale = "fr" }: SectionServicesProps) {
+  const content = getPortfolioContent(locale).services;
+  const services = content.items;
 
   return (
     <section id="services" className={styles.section} aria-labelledby="services-title">
       <div className={styles.container}>
         <header className={styles.header}>
           <h2 id="services-title" className={styles.title}>
-            Services
+            {content.title}
           </h2>
-          <p className={styles.subtitle}>
-            Des offres concrètes pour transformer un besoin métier en solution
-            livrée, exploitable et évolutive.
-          </p>
+          <p className={styles.subtitle}>{content.subtitle}</p>
         </header>
 
         <div className={styles.grid}>
@@ -45,7 +46,7 @@ export function SectionServices() {
                 className={styles.cardAction}
                 aria-label={`Me contacter pour ${service.title}`}
               >
-                Discuter de ce service
+                {locale === "fr" ? "Discuter de ce service" : "Discuss this service"}
               </a>
             </article>
           ))}
@@ -53,8 +54,9 @@ export function SectionServices() {
 
         {services.length === 0 ? (
           <p className={styles.fallback}>
-            Les services sont temporairement indisponibles. Vous pouvez me
-            contacter directement via la section contact.
+            {locale === "fr"
+              ? "Les services sont temporairement indisponibles. Vous pouvez me contacter directement via la section contact."
+              : "Services are temporarily unavailable. You can still contact me directly from the contact section."}
           </p>
         ) : null}
       </div>

--- a/components/sectionSkills/sectionSkills.extensions.ts
+++ b/components/sectionSkills/sectionSkills.extensions.ts
@@ -29,41 +29,80 @@ type RawSkill = {
 
 const CATEGORY_ORDER: Array<{
   id: string;
-  label: string;
-  supportText: string;
+  label: Record<SkillsLocale, string>;
+  supportText: Record<SkillsLocale, string>;
   sourceCategories: string[];
 }> = [
   {
     id: "fullstack-dotnet",
-    label: "Fullstack .NET",
-    supportText: "Le socle principal pour concevoir, livrer et faire évoluer des applications robustes.",
+    label: { fr: "Fullstack .NET", en: "Fullstack .NET" },
+    supportText: {
+      fr: "Le socle principal pour concevoir, livrer et faire evoluer des applications robustes.",
+      en: "The core stack used to design, ship, and evolve reliable applications.",
+    },
     sourceCategories: ["Technology"],
   },
   {
     id: "frontend-architecture",
-    label: "Front-end & Architecture",
-    supportText: "Interfaces web, structuration technique et choix d'architecture orientés usage.",
+    label: { fr: "Front-end & Architecture", en: "Front-end & Architecture" },
+    supportText: {
+      fr: "Interfaces web, structuration technique et choix d'architecture orientes usage.",
+      en: "Web interfaces, technical structure, and architecture choices driven by actual usage.",
+    },
     sourceCategories: ["other"],
   },
   {
     id: "data-cloud",
-    label: "Data & Cloud",
-    supportText: "Persistance, services cloud et outils pour des solutions prêtes à l'exploitation.",
+    label: { fr: "Data & Cloud", en: "Data & Cloud" },
+    supportText: {
+      fr: "Persistance, services cloud et outils pour des solutions pretes a l'exploitation.",
+      en: "Persistence, cloud services, and tooling to support production-ready solutions.",
+    },
     sourceCategories: ["database"],
   },
   {
     id: "delivery-tooling",
-    label: "Delivery & Outils",
-    supportText: "Environnement de production, collaboration d'équipe et suivi du delivery.",
+    label: { fr: "Delivery & Outils", en: "Delivery & Tooling" },
+    supportText: {
+      fr: "Environnement de production, collaboration d'equipe et suivi du delivery.",
+      en: "Production environment, team collaboration, and delivery execution tooling.",
+    },
     sourceCategories: ["software"],
   },
   {
     id: "environment-collaboration",
-    label: "Environnements & Qualités humaines",
-    supportText: "Capacité à intervenir dans des contextes variés avec autonomie et esprit d'équipe.",
+    label: { fr: "Environnements & Qualites humaines", en: "Environments & Human qualities" },
+    supportText: {
+      fr: "Capacite a intervenir dans des contextes varies avec autonomie et esprit d'equipe.",
+      en: "Ability to contribute across varied environments with autonomy and strong collaboration.",
+    },
     sourceCategories: ["operatingsystem", "qualification"],
   },
 ];
+
+const SKILL_LABEL_TRANSLATIONS: Record<string, string> = {
+  "Bases du Web": "Web fundamentals",
+  Javascript: "JavaScript",
+  Architectures: "Architectures",
+  "Gestion de projet / Equipe": "Project delivery / Team collaboration",
+  "Esprit d'équipe": "Team spirit",
+  Autodidacte: "Self-taught",
+  Dynamique: "Driven",
+  "Méthodique": "Methodical",
+  Autonome: "Autonomous",
+};
+
+const SKILL_DESCRIPTION_TRANSLATIONS: Record<string, string> = {
+  "Core / MVC / WebForm": "Core / MVC / WebForm",
+  "Service bus / App services / Azure functions / Storage Account / Monitoring / App Insight / ...": "Service bus / App services / Azure Functions / Storage Account / Monitoring / App Insights / ...",
+  "SQL Server Integration Services / SQL Server Reporting Services": "SQL Server Integration Services / SQL Server Reporting Services",
+  "HTML5 / CSS3": "HTML5 / CSS3",
+  "Jquery / VueJS / React / TabAjax": "jQuery / Vue.js / React / TabAjax",
+  "Design patterns / CQRS / DDD": "Design patterns / CQRS / DDD",
+  "Agile (Scrum) / Cycle en V / Scrum Master / Reviewer": "Agile (Scrum) / V-cycle / Scrum Master / Reviewer",
+  "IDE / Code": "IDE / Code",
+  "Photoshop / InDesign": "Photoshop / InDesign",
+};
 
 const SECTION_METADATA: Record<SkillsLocale, SkillsSectionMetadata> = {
   fr: {
@@ -88,19 +127,29 @@ function isNonEmptyString(value: unknown): value is string {
   return typeof value === "string" && value.trim().length > 0;
 }
 
-function toSkillItem(item: RawSkill): SkillItem | null {
+function translateValue(value: string, locale: SkillsLocale, translations: Record<string, string>): string {
+  if (locale === "fr") {
+    return value;
+  }
+
+  return translations[value] || value;
+}
+
+function toSkillItem(item: RawSkill, locale: SkillsLocale): SkillItem | null {
   if (!isNonEmptyString(item.label)) {
     return null;
   }
 
   return {
-    label: item.label,
-    description: isNonEmptyString(item.description) ? item.description : null,
+    label: translateValue(item.label, locale, SKILL_LABEL_TRANSLATIONS),
+    description: isNonEmptyString(item.description)
+      ? translateValue(item.description, locale, SKILL_DESCRIPTION_TRANSLATIONS)
+      : null,
     position: typeof item.position === "number" ? item.position : Number.MAX_SAFE_INTEGER,
   };
 }
 
-export function normalizeSkills(items: unknown): SkillCategory[] {
+export function normalizeSkills(items: unknown, locale: SkillsLocale = "fr"): SkillCategory[] {
   if (!Array.isArray(items)) {
     return [];
   }
@@ -131,7 +180,7 @@ export function normalizeSkills(items: unknown): SkillCategory[] {
       return;
     }
 
-    const normalizedSkill = toSkillItem(rawSkill);
+    const normalizedSkill = toSkillItem(rawSkill, locale);
     if (!normalizedSkill) {
       return;
     }
@@ -152,7 +201,10 @@ export function normalizeSkills(items: unknown): SkillCategory[] {
   });
 
   return CATEGORY_ORDER.map((category) => ({
-    ...category,
+    id: category.id,
+    label: category.label[locale],
+    supportText: category.supportText[locale],
+    sourceCategories: category.sourceCategories,
     skills: (grouped.get(category.id) || []).sort((left, right) => {
       if (left.position !== right.position) {
         return left.position - right.position;

--- a/components/sectionSkills/sectionSkills.module.scss
+++ b/components/sectionSkills/sectionSkills.module.scss
@@ -1,27 +1,30 @@
+/* ─── Section wrapper ──────────────────────────────────────────────────── */
+
 .section {
 	width: 100%;
-	padding: 5rem 1.25rem;
+	padding: 6rem 1.25rem;
 	background:
-          radial-gradient(circle at 10% 12%, rgba(14, 165, 233, 0.10), transparent 34%),
-          radial-gradient(circle at 88% 82%, rgba(15, 23, 42, 0.08), transparent 30%),
-          #f8fbfc;
+		radial-gradient(circle at 8% 10%, rgba(47, 107, 255, 0.07), transparent 40%),
+		radial-gradient(circle at 92% 85%, rgba(217, 119, 6, 0.06), transparent 40%),
+		#f1f5f9;
 }
 
 .container {
-	max-width: 1140px;
+	max-width: 1200px;
 	margin: 0 auto;
 }
 
 .header {
 	max-width: 760px;
-	margin-bottom: 2rem;
+	margin-bottom: 2.5rem;
 }
 
 .title {
 	margin: 0;
 	color: #0f172a;
-	font-size: clamp(1.95rem, 2.5vw, 2.6rem);
-	letter-spacing: -0.02em;
+	font-family: var(--font-display);
+	font-size: clamp(2.2rem, 3vw, 3.2rem);
+	letter-spacing: -0.03em;
 }
 
 .subtitle {
@@ -31,82 +34,289 @@
 	font-size: 1.02rem;
 }
 
-.grid {
+/* ─── Diagram panel ──────────────────────────────────────────────────── */
+
+.diagram {
+	position: relative;
 	display: grid;
-	grid-template-columns: repeat(3, minmax(0, 1fr));
-	gap: 1rem;
+	grid-template-columns: repeat(5, minmax(0, 1fr));
+	gap: 0 1.25rem;
+
+	/* Blueprint dot-grid background */
+	background-color: rgba(255, 255, 255, 0.65);
+	background-image: radial-gradient(circle, rgba(100, 116, 139, 0.18) 1.2px, transparent 1.2px);
+	background-size: 22px 22px;
+	border-radius: 32px;
+	border: 1px solid rgba(148, 163, 184, 0.2);
+	padding: 2.5rem 2rem;
+	box-shadow:
+		inset 0 1px 0 rgba(255, 255, 255, 0.9),
+		0 24px 60px rgba(15, 23, 42, 0.06);
+
+	/* Horizontal connector line through all node orbs */
+	&::before {
+		content: "";
+		position: absolute;
+		top: calc(2.5rem + 22px);
+		left: 12%;
+		right: 12%;
+		height: 2px;
+		background: linear-gradient(
+			to right,
+			rgba(59, 130, 246, 0),
+			rgba(59, 130, 246, 0.55) 12%,
+			rgba(139, 92, 246, 0.5) 30%,
+			rgba(6, 182, 212, 0.5) 50%,
+			rgba(16, 185, 129, 0.5) 70%,
+			rgba(245, 158, 11, 0.55) 88%,
+			rgba(245, 158, 11, 0)
+		);
+		z-index: 0;
+		pointer-events: none;
+	}
 }
 
-.card {
+/* ─── Node column ────────────────────────────────────────────────────── */
+
+.node {
 	display: flex;
 	flex-direction: column;
-	gap: 0.8rem;
-	padding: 1.1rem;
-  border-radius: 16px;
-  border: 1px solid #dbe4f3;
-  background: #ffffff;
-  box-shadow: 0 10px 24px rgba(15, 23, 42, 0.06);
+	align-items: center;
+	min-width: 0;
 }
 
-.cardTitle {
-	margin: 0;
+.nodeHead {
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	position: relative;
+	z-index: 1;
+}
+
+.nodeOrb {
+	width: 44px;
+	height: 44px;
+	border-radius: 50%;
+	border: 3px solid #fff;
+	flex-shrink: 0;
+	position: relative;
+
+	/* Inner specular highlight */
+	&::after {
+		content: "";
+		position: absolute;
+		inset: 0;
+		border-radius: 50%;
+		background: radial-gradient(circle at 34% 34%, rgba(255, 255, 255, 0.6), transparent 58%);
+	}
+}
+
+.nodeVline {
+	width: 2px;
+	height: 26px;
+	flex-shrink: 0;
+}
+
+/* ─── Node body card ─────────────────────────────────────────────────── */
+
+.nodeBody {
+	background: rgba(255, 255, 255, 0.9);
+	border: 1px solid rgba(148, 163, 184, 0.22);
+	border-radius: 20px;
+	padding: 1rem 0.9rem;
+	width: 100%;
+	box-shadow: 0 4px 16px rgba(15, 23, 42, 0.05);
+}
+
+.nodeLabel {
+	margin: 0 0 0.35rem;
 	color: #0f172a;
-	font-size: 1.05rem;
+	font-family: var(--font-display);
+	font-size: 0.9rem;
+	font-weight: 700;
+	line-height: 1.3;
 }
 
-.cardSupport {
-	margin: 0;
-	color: #475569;
-	line-height: 1.6;
-	font-size: 0.92rem;
+.nodeSupport {
+	margin: 0 0 0.8rem;
+	color: #64748b;
+	font-size: 0.76rem;
+	line-height: 1.5;
 }
 
-.skillsList {
+/* ─── Skill chips ────────────────────────────────────────────────────── */
+
+.chipList {
+	list-style: none;
 	margin: 0;
 	padding: 0;
-	list-style: none;
-	display: grid;
-  gap: 0.45rem;
+	display: flex;
+	flex-wrap: wrap;
+	gap: 0.3rem;
 }
 
-.skillItem {
-  border-radius: 10px;
-  background: #f8fbff;
-  border: 1px solid #e0e8f6;
-  padding: 0.6rem 0.65rem;
+.chip {
+	border-radius: 100px;
+	padding: 0.18rem 0.55rem;
+	font-size: 0.74rem;
+	font-weight: 500;
+	cursor: default;
+	white-space: nowrap;
+	transition:
+		background-color 0.15s,
+		border-color 0.15s;
+	border-width: 1px;
+	border-style: solid;
 }
 
-.skillLabel {
-	margin: 0;
-  color: #14213d;
-  font-weight: 600;
-  font-size: 0.9rem;
+/* ─── Per-node color themes (nth-child on .node) ─────────────────────── */
+
+/* 1 — Fullstack .NET → blue */
+.node:nth-child(1) {
+	.nodeOrb {
+		background: linear-gradient(135deg, #3b82f6, #1d4ed8);
+		box-shadow:
+			0 0 0 4px rgba(59, 130, 246, 0.14),
+			0 0 22px rgba(59, 130, 246, 0.28);
+	}
+	.nodeVline {
+		background: linear-gradient(to bottom, rgba(59, 130, 246, 0.45), transparent);
+	}
+	.chip {
+		background: rgba(59, 130, 246, 0.07);
+		border-color: rgba(59, 130, 246, 0.22);
+		color: #1e40af;
+		&:hover {
+			background: rgba(59, 130, 246, 0.14);
+			border-color: rgba(59, 130, 246, 0.4);
+		}
+	}
 }
 
-.skillDescription {
-  margin: 0.32rem 0 0;
-  color: #475569;
-  line-height: 1.5;
-  font-size: 0.84rem;
+/* 2 — Front-end & Architecture → purple */
+.node:nth-child(2) {
+	.nodeOrb {
+		background: linear-gradient(135deg, #8b5cf6, #5b21b6);
+		box-shadow:
+			0 0 0 4px rgba(139, 92, 246, 0.14),
+			0 0 22px rgba(139, 92, 246, 0.28);
+	}
+	.nodeVline {
+		background: linear-gradient(to bottom, rgba(139, 92, 246, 0.45), transparent);
+	}
+	.chip {
+		background: rgba(139, 92, 246, 0.07);
+		border-color: rgba(139, 92, 246, 0.22);
+		color: #4c1d95;
+		&:hover {
+			background: rgba(139, 92, 246, 0.14);
+			border-color: rgba(139, 92, 246, 0.4);
+		}
+	}
 }
+
+/* 3 — Data & Cloud → cyan */
+.node:nth-child(3) {
+	.nodeOrb {
+		background: linear-gradient(135deg, #06b6d4, #0e7490);
+		box-shadow:
+			0 0 0 4px rgba(6, 182, 212, 0.14),
+			0 0 22px rgba(6, 182, 212, 0.28);
+	}
+	.nodeVline {
+		background: linear-gradient(to bottom, rgba(6, 182, 212, 0.45), transparent);
+	}
+	.chip {
+		background: rgba(6, 182, 212, 0.07);
+		border-color: rgba(6, 182, 212, 0.22);
+		color: #155e75;
+		&:hover {
+			background: rgba(6, 182, 212, 0.14);
+			border-color: rgba(6, 182, 212, 0.4);
+		}
+	}
+}
+
+/* 4 — Delivery & Tooling → green */
+.node:nth-child(4) {
+	.nodeOrb {
+		background: linear-gradient(135deg, #10b981, #047857);
+		box-shadow:
+			0 0 0 4px rgba(16, 185, 129, 0.14),
+			0 0 22px rgba(16, 185, 129, 0.28);
+	}
+	.nodeVline {
+		background: linear-gradient(to bottom, rgba(16, 185, 129, 0.45), transparent);
+	}
+	.chip {
+		background: rgba(16, 185, 129, 0.07);
+		border-color: rgba(16, 185, 129, 0.22);
+		color: #065f46;
+		&:hover {
+			background: rgba(16, 185, 129, 0.14);
+			border-color: rgba(16, 185, 129, 0.4);
+		}
+	}
+}
+
+/* 5 — Environments & Human qualities → amber */
+.node:nth-child(5) {
+	.nodeOrb {
+		background: linear-gradient(135deg, #f59e0b, #b45309);
+		box-shadow:
+			0 0 0 4px rgba(245, 158, 11, 0.14),
+			0 0 22px rgba(245, 158, 11, 0.28);
+	}
+	.nodeVline {
+		background: linear-gradient(to bottom, rgba(245, 158, 11, 0.45), transparent);
+	}
+	.chip {
+		background: rgba(245, 158, 11, 0.07);
+		border-color: rgba(245, 158, 11, 0.22);
+		color: #78350f;
+		&:hover {
+			background: rgba(245, 158, 11, 0.14);
+			border-color: rgba(245, 158, 11, 0.4);
+		}
+	}
+}
+
+/* ─── Fallback ───────────────────────────────────────────────────────── */
 
 .fallback {
 	margin-top: 1rem;
 	color: #475569;
 }
 
-@media (max-width: 1024px) {
-	.grid {
-		grid-template-columns: repeat(2, minmax(0, 1fr));
+/* ─── Responsive ─────────────────────────────────────────────────────── */
+
+@media (max-width: 1100px) {
+	.diagram {
+		grid-template-columns: repeat(3, minmax(0, 1fr));
+		gap: 2rem 1rem;
+		padding: 2rem 1.5rem;
+
+		&::before {
+			display: none;
+		}
 	}
 }
 
 @media (max-width: 700px) {
 	.section {
-		padding: 3.5rem 1rem;
+		padding: 4rem 1rem;
 	}
 
-	.grid {
+	.diagram {
+		grid-template-columns: repeat(2, minmax(0, 1fr));
+		gap: 1.5rem 0.75rem;
+		padding: 1.5rem 1rem;
+	}
+}
+
+@media (max-width: 420px) {
+	.diagram {
 		grid-template-columns: 1fr;
+		gap: 1.25rem;
 	}
 }

--- a/components/sectionSkills/sectionSkills.tsx
+++ b/components/sectionSkills/sectionSkills.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { PortfolioLocale } from "../../content/portfolioContent";
 import styles from "./sectionSkills.module.scss";
 import skillsData from "../../public/data/skills.json";
 import {
@@ -7,10 +8,13 @@ import {
   SkillsLocale,
 } from "./sectionSkills.extensions";
 
-export function SectionSkills() {
-  const locale: SkillsLocale = "fr";
+type SectionSkillsProps = {
+  locale?: PortfolioLocale;
+};
+
+export function SectionSkills({ locale = "fr" }: SectionSkillsProps) {
   const metadata = resolveSkillsSectionMetadata(locale);
-  const categories = normalizeSkills(skillsData);
+  const categories = normalizeSkills(skillsData, locale as SkillsLocale);
 
   return (
     <section id="skills" className={styles.section} aria-labelledby="skills-title">
@@ -22,23 +26,29 @@ export function SectionSkills() {
           <p className={styles.subtitle}>{metadata.subtitle}</p>
         </header>
 
-        <div className={styles.grid}>
+        <div className={styles.diagram}>
           {categories.map((category) => (
-            <article key={category.id} className={styles.card}>
-              <h3 className={styles.cardTitle}>{category.label}</h3>
-              <p className={styles.cardSupport}>{category.supportText}</p>
-
-              <ul className={styles.skillsList}>
-                {category.skills.map((skill) => (
-                  <li key={`${category.id}-${skill.label}`} className={styles.skillItem}>
-                    <p className={styles.skillLabel}>{skill.label}</p>
-                    {skill.description ? (
-                      <p className={styles.skillDescription}>{skill.description}</p>
-                    ) : null}
-                  </li>
-                ))}
-              </ul>
-            </article>
+            <div key={category.id} className={styles.node}>
+              <div className={styles.nodeHead}>
+                <div className={styles.nodeOrb} aria-hidden="true" />
+                <div className={styles.nodeVline} aria-hidden="true" />
+              </div>
+              <div className={styles.nodeBody}>
+                <h3 className={styles.nodeLabel}>{category.label}</h3>
+                <p className={styles.nodeSupport}>{category.supportText}</p>
+                <ul className={styles.chipList}>
+                  {category.skills.map((skill) => (
+                    <li
+                      key={`${category.id}-${skill.label}`}
+                      className={styles.chip}
+                      title={skill.description ?? undefined}
+                    >
+                      {skill.label}
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            </div>
           ))}
         </div>
 

--- a/components/sectionWorkExperiences/sectionWorkExperiences.module.scss
+++ b/components/sectionWorkExperiences/sectionWorkExperiences.module.scss
@@ -1,7 +1,9 @@
 .section {
 	width: 100%;
-	padding: 5rem 1.25rem;
-	background: linear-gradient(180deg, #ffffff 0%, #f7f9fc 100%);
+	padding: 6rem 1.25rem;
+	background:
+		radial-gradient(circle at 80% 12%, rgba(198, 139, 89, 0.08), transparent 24%),
+		linear-gradient(180deg, #f7f9fc 0%, #edf2f8 100%);
 }
 
 .container {
@@ -17,8 +19,9 @@
 .title {
 	margin: 0;
 	color: #0f172a;
-	font-size: clamp(1.95rem, 2.5vw, 2.6rem);
-	letter-spacing: -0.02em;
+	font-family: var(--font-display);
+	font-size: clamp(2.2rem, 3vw, 3.2rem);
+	letter-spacing: -0.03em;
 }
 
 .subtitle {
@@ -31,57 +34,60 @@
 .timeline {
 	position: relative;
 	display: grid;
-	gap: 1rem;
+	gap: 1.15rem;
 }
 
 .timeline::before {
 	content: "";
 	position: absolute;
-	left: 0.62rem;
+	left: 0.8rem;
 	top: 0;
 	bottom: 0;
 	width: 2px;
-	background: linear-gradient(180deg, #0f172a 0%, #64748b 100%);
+	background: linear-gradient(180deg, #0f172a 0%, #2f6bff 50%, #c68b59 100%);
 }
 
 .card {
 	position: relative;
-	margin-left: 2rem;
-	border: 1px solid #d7e0f1;
-	border-radius: 16px;
-	background: #ffffff;
-	box-shadow: 0 10px 24px rgba(15, 23, 42, 0.06);
-	padding: 1rem 1.05rem;
+	margin-left: 2.4rem;
+	border: 1px solid rgba(148, 163, 184, 0.18);
+	border-radius: 24px;
+	background: rgba(255, 255, 255, 0.88);
+	box-shadow: 0 18px 44px rgba(15, 23, 42, 0.06);
+	padding: 1.2rem 1.2rem;
 }
 
 .card::before {
 	content: "";
 	position: absolute;
-	left: -1.8rem;
+	left: -2.05rem;
 	top: 1.15rem;
-	width: 11px;
-	height: 11px;
+	width: 14px;
+	height: 14px;
 	border-radius: 50%;
-	background: #0f172a;
+	background: linear-gradient(135deg, #2f6bff 0%, #c68b59 100%);
+	box-shadow: 0 0 0 5px rgba(255, 255, 255, 0.95);
 }
 
 .period {
 	margin: 0;
-	color: #0f172a;
+	color: #40618c;
 	font-weight: 700;
-	font-size: 0.9rem;
+	font-size: 0.82rem;
+	letter-spacing: 0.14em;
+	text-transform: uppercase;
 }
 
 .role {
 	margin: 0.3rem 0 0;
 	color: #0f172a;
-	font-size: 1.05rem;
+	font-size: 1.14rem;
 }
 
 .organization {
 	margin: 0.2rem 0 0.7rem;
 	color: #334155;
-	font-weight: 500;
+	font-weight: 600;
 }
 
 .blockLabel {
@@ -123,22 +129,23 @@
 	display: inline-flex;
 	align-items: center;
 	justify-content: center;
-	border-radius: 10px;
+	border-radius: 999px;
 	background: #0f172a;
 	color: #ffffff;
 	text-decoration: none;
 	font-weight: 600;
-	padding: 0.65rem 0.95rem;
+	padding: 0.78rem 1.05rem;
 }
 
 .educationCta:hover,
 .educationCta:focus-visible {
 	opacity: 0.95;
+	transform: translateY(-1px);
 }
 
 @media (max-width: 700px) {
 	.section {
-		padding: 3.5rem 1rem;
+		padding: 4.2rem 1rem;
 	}
 
 	.timeline::before {

--- a/components/sectionWorkExperiences/sectionWorkExperiences.tsx
+++ b/components/sectionWorkExperiences/sectionWorkExperiences.tsx
@@ -1,82 +1,26 @@
 import React from "react";
+import { PortfolioLocale, getPortfolioContent } from "../../content/portfolioContent";
 import styles from "./sectionWorkExperiences.module.scss";
 
-type ExperienceEntry = {
-  roleTitle: string;
-  organizationLabel: string;
-  period: string;
-  context: string;
-  valueDelivered: string;
-  tech: string[];
+type SectionWorkExperiencesProps = {
+  locale?: PortfolioLocale;
 };
 
-const ENTRIES: ExperienceEntry[] = [
-  {
-    roleTitle: "Ingénieur Développement Fullstack .NET",
-    organizationLabel: "SMEG, Monaco",
-    period: "Nov. 2023 - Aujourd'hui",
-    context:
-      "Gestion des appels d'astreinte, d'urgence et interventions pour des usages bureau et mobile.",
-    valueDelivered:
-      "Conception et livraison d'une solution robuste, orientée fiabilité opérationnelle et réactivité terrain.",
-    tech: [".NET 7", "C#", "ABP", "DDD", "Azure", "Docker", "RabbitMQ", "Redis", "MongoDB"],
-  },
-  {
-    roleTitle: "Ingénieur Développement Fullstack .NET",
-    organizationLabel: "Groupe C8G",
-    period: "Juin 2023 - Aujourd'hui",
-    context:
-      "Développement de solutions web métier orientées usages internes et efficacité quotidienne.",
-    valueDelivered:
-      "Mise en production de fonctionnalités fullstack accélérant la livraison et la maintenabilité des produits.",
-    tech: [".NET", "Blazor", "Entity Framework", "Azure", "Vue.js"],
-  },
-  {
-    roleTitle: "Développeur Back-end .NET",
-    organizationLabel: "TidyUp Technologies",
-    period: "Juin 2023 - Oct. 2023",
-    context:
-      "Plateforme de rangement, classement et recherche de contenus numériques avec composante IA.",
-    valueDelivered:
-      "Construction d'un socle backend pérenne pour la recherche de contenus et l'évolution produit.",
-    tech: [".NET MVC", ".NET Core", "C#", "Xamarin Forms", "SQL"],
-  },
-  {
-    roleTitle: "Développeur Back-end .NET",
-    organizationLabel: "UBALDI.com",
-    period: "Avr. 2021 - Juin 2023",
-    context: "Contribution à plusieurs projets internes orientés continuité de service et performance.",
-    valueDelivered:
-      "Fiabilisation du delivery backend et amélioration continue des processus techniques internes.",
-    tech: [".NET", "C#", "API", "SQL Server"],
-  },
-  {
-    roleTitle: "Développeur Fullstack .NET",
-    organizationLabel: "Régie Eau d'Azur",
-    period: "Sept. 2015 - Avr. 2021",
-    context:
-      "Réalisation de solutions applicatives internes sur un cycle long avec contraintes métier variées.",
-    valueDelivered:
-      "Industrialisation progressive des applications et renforcement de la qualité de service utilisateur.",
-    tech: [".NET", "C#", "SQL", "Architecture applicative"],
-  },
-];
+export function SectionWorkExperiences({ locale = "fr" }: SectionWorkExperiencesProps) {
+  const content = getPortfolioContent(locale).experience;
 
-export function SectionWorkExperiences() {
   return (
     <section id="experience" className={styles.section} aria-labelledby="experience-title">
       <div className={styles.container}>
         <header className={styles.header}>
           <h2 id="experience-title" className={styles.title}>
-            Expérience
+            {content.title}
           </h2>
-          <p className={styles.subtitle}>
-            Des missions réelles, menées de bout en bout, avec un focus constant sur la valeur livrée.
-          </p>
+          <p className={styles.subtitle}>{content.subtitle}</p>
         </header>
 
         <div className={styles.timeline}>
-          {ENTRIES.map((entry) => (
+          {content.entries.map((entry) => (
             <article key={`${entry.roleTitle}-${entry.organizationLabel}-${entry.period}`} className={styles.card}>
               <p className={styles.period}>{entry.period}</p>
               <h3 className={styles.role}>{entry.roleTitle}</h3>
@@ -97,7 +41,7 @@ export function SectionWorkExperiences() {
         </div>
 
         <a href="#educations" className={styles.educationCta}>
-          Voir le parcours de formation
+          {content.educationCta}
         </a>
       </div>
     </section>

--- a/content/portfolioContent.ts
+++ b/content/portfolioContent.ts
@@ -1,0 +1,664 @@
+export type PortfolioLocale = "fr" | "en";
+
+type NavigationItem = {
+  id: string;
+  label: string;
+};
+
+type HeroMetric = {
+  value: string;
+  label: string;
+};
+
+type ActionLink = {
+  label: string;
+  href: string;
+};
+
+type AboutHighlight = {
+  title: string;
+  description: string;
+};
+
+type ServiceOffer = {
+  title: string;
+  clientProblem: string;
+  businessOutcome: string;
+  capabilities: string[];
+  ctaTarget: string;
+};
+
+type ExperienceEntry = {
+  roleTitle: string;
+  organizationLabel: string;
+  period: string;
+  context: string;
+  valueDelivered: string;
+  tech: string[];
+};
+
+type EducationEntry = {
+  period: string;
+  title: string;
+  institution: string;
+  description: string;
+};
+
+type ProjectEntry = {
+  title: string;
+  summary: string;
+  context: string;
+  contribution: string;
+  outcome: string;
+  tags: string[];
+  publicLink?: string;
+};
+
+type FooterLink = {
+  label: string;
+  href: string;
+};
+
+export type PortfolioContent = {
+  localeName: string;
+  switchLocaleLabel: string;
+  meta: {
+    title: string;
+    description: string;
+  };
+  navigation: {
+    items: NavigationItem[];
+    ctaLabel: string;
+    localeSwitcherLabel: string;
+  };
+  hero: {
+    eyebrow: string;
+    name: string;
+    tagline: string;
+    promise: string;
+    proofPoints: string[];
+    metrics: HeroMetric[];
+    primaryAction: ActionLink;
+    secondaryAction: ActionLink;
+  };
+  about: {
+    title: string;
+    lead: string;
+    paragraphs: string[];
+    highlights: AboutHighlight[];
+    principles: string[];
+    primaryAction: ActionLink;
+    secondaryAction: ActionLink;
+  };
+  services: {
+    title: string;
+    subtitle: string;
+    items: ServiceOffer[];
+  };
+  experience: {
+    title: string;
+    subtitle: string;
+    entries: ExperienceEntry[];
+    educationCta: string;
+  };
+  education: {
+    title: string;
+    subtitle: string;
+    entries: EducationEntry[];
+    continuousLearningTitle: string;
+    continuousLearningText: string;
+  };
+  projects: {
+    title: string;
+    subtitle: string;
+    items: ProjectEntry[];
+    primaryAction: ActionLink;
+    secondaryAction: ActionLink;
+  };
+  contact: {
+    title: string;
+    description: string;
+    inquiryTypes: string[];
+    primaryActionLabel: string;
+    copyActionLabel: string;
+    copySuccess: string;
+    copyUnavailable: string;
+    copyError: string;
+    emailLabel: string;
+    meta: string;
+    responsePromise: string;
+  };
+  footer: {
+    baseline: string;
+    availability: string;
+    navigationTitle: string;
+    links: FooterLink[];
+    contactTitle: string;
+    rights: string;
+  };
+};
+
+const NAV_IDS: Array<{ id: string; fr: string; en: string }> = [
+  { id: "hero", fr: "Accueil", en: "Home" },
+  { id: "about", fr: "A propos", en: "About" },
+  { id: "services", fr: "Services", en: "Services" },
+  { id: "skills", fr: "Competences", en: "Skills" },
+  { id: "experience", fr: "Experience", en: "Experience" },
+  { id: "projects", fr: "Projets", en: "Projects" },
+  { id: "contact", fr: "Contact", en: "Contact" },
+];
+
+const EMAIL = "passe.valentin@gmail.com";
+
+export const portfolioContent: Record<PortfolioLocale, PortfolioContent> = {
+  fr: {
+    localeName: "FR",
+    switchLocaleLabel: "EN",
+    meta: {
+      title: "Valentin PASSE | Freelance Fullstack .NET",
+      description:
+        "Portfolio one-page de Valentin PASSE, freelance Fullstack .NET a Nice. Delivery produit, architecture applicative et integration IA pragmatique.",
+    },
+    navigation: {
+      items: NAV_IDS.map((item) => ({ id: item.id, label: item.fr })),
+      ctaLabel: "Parler de votre projet",
+      localeSwitcherLabel: "Basculer la langue du portfolio",
+    },
+    hero: {
+      eyebrow: "Freelance Fullstack .NET | Nice, remote, hybride, sur site",
+      name: "Valentin Passe",
+      tagline: "Je conçois des produits web fiables, lisibles et rapides a faire evoluer.",
+      promise:
+        "J'interviens sur le cadrage, le developpement fullstack .NET, la qualite de delivery et l'integration IA utile pour accelerer les equipes sans ajouter de dette inutile.",
+      proofPoints: [
+        "Double experience CDI et freelance pour arbitrer vite entre vision produit et contraintes de livraison.",
+        "Expertise .NET, Blazor, architecture applicative et contextes metier exigeants.",
+        "Approche directe, orientee resultat, avec attention forte a la lisibilite du code et a l'usage final.",
+      ],
+      metrics: [
+        { value: "10+", label: "ans de delivery logiciel" },
+        { value: "2", label: "missions freelance en parallele depuis 2023" },
+        { value: ".NET", label: "socle principal pour construire et faire evoluer" },
+      ],
+      primaryAction: { label: "Discuter de votre besoin", href: "#contact" },
+      secondaryAction: { label: "Voir les projets", href: "#projects" },
+    },
+    about: {
+      title: "A propos",
+      lead:
+        "Ingenieur Fullstack .NET freelance, j'aide les entreprises a transformer un besoin metier en produit web robuste et exploitable.",
+      paragraphs: [
+        "J'interviens sur toute la chaine de valeur: cadrage, architecture, implementation, qualite et mise en production. Mon objectif est simple: livrer vite, proprement, et sans sacrifier la maintenabilite.",
+        "Mon positionnement combine rigueur technique, vision produit et integration IA pragmatique. J'aime les solutions claires, utiles et compréhensibles par l'equipe qui devra ensuite les faire vivre.",
+      ],
+      highlights: [
+        {
+          title: "Execution end-to-end",
+          description: "Du besoin initial a la livraison, je garde un cap de resultat et une vision d'ensemble sur le produit.",
+        },
+        {
+          title: "Fullstack .NET assume",
+          description: "Back-end, API, front Blazor et architecture applicative pour eviter les zones mortes entre couches.",
+        },
+        {
+          title: "Pragmatique sur l'IA",
+          description: "J'integre l'IA quand elle simplifie vraiment un workflow, pas pour ajouter une couche de complexite de plus.",
+        },
+      ],
+      principles: ["Concevoir", "Livrer", "Fiabiliser", "Faire evoluer"],
+      primaryAction: { label: "Explorer les projets", href: "#projects" },
+      secondaryAction: { label: "Me contacter", href: "#contact" },
+    },
+    services: {
+      title: "Services",
+      subtitle:
+        "Trois modes d'intervention pour structurer une roadmap, renforcer un produit existant ou accelerer des gains concrets avec l'IA.",
+      items: [
+        {
+          title: "Cadrage et trajectoire technique",
+          clientProblem:
+            "Le besoin est clair cote metier, mais la solution manque encore de structure technique pour demarrer sans dispersion.",
+          businessOutcome:
+            "Vous obtenez des choix d'architecture argumentes, un decoupage livrable et une trajectoire de delivery credible.",
+          capabilities: ["Ateliers de cadrage", "Architecture .NET", "Roadmap priorisee"],
+          ctaTarget: "#contact",
+        },
+        {
+          title: "Developpement Fullstack .NET",
+          clientProblem:
+            "Le produit doit evoluer vite sans degrader la lisibilite du code, la performance ou la capacite a maintenir dans le temps.",
+          businessOutcome:
+            "Vous accelerez la mise en production avec une implementation robuste, comprehensible et alignee sur les usages terrain.",
+          capabilities: ["API et back-end .NET", "Interfaces Blazor", "Qualite et performance"],
+          ctaTarget: "#contact",
+        },
+        {
+          title: "Automatisation et IA utile",
+          clientProblem:
+            "Les equipes perdent du temps sur des operations repetitives et cherchent des gains rapides sans projet usine a gaz.",
+          businessOutcome:
+            "Vous ciblez des automatisations a fort effet utile avec une integration IA sobre, mesurable et adaptee au contexte.",
+          capabilities: ["Audit de workflows", "Automatisations ciblees", "Accompagnement a l'adoption"],
+          ctaTarget: "#contact",
+        },
+      ],
+    },
+    experience: {
+      title: "Experience",
+      subtitle:
+        "Des missions menees dans la duree, avec des environnements operationnels exigeants et une attention constante a la valeur livree.",
+      entries: [
+        {
+          roleTitle: "Ingenieur Developpement Fullstack .NET",
+          organizationLabel: "SMEG, Monaco",
+          period: "Nov. 2023 - Aujourd'hui",
+          context:
+            "Solution de gestion des appels d'astreinte, urgences et interventions pour des usages bureau et mobile.",
+          valueDelivered:
+            "Conception et livraison d'un systeme fiable pour des situations critiques, avec une meilleure reactivite terrain.",
+          tech: [".NET 7", "C#", "ABP", "DDD", "Azure", "Docker", "RabbitMQ", "Redis", "MongoDB"],
+        },
+        {
+          roleTitle: "Ingenieur Developpement Fullstack .NET",
+          organizationLabel: "Groupe C8G",
+          period: "Juin 2023 - Aujourd'hui",
+          context:
+            "Developpement de solutions web metier pour soutenir les usages internes et la rapidite d'execution des equipes.",
+          valueDelivered:
+            "Mise en production de fonctionnalites fullstack qui fluidifient le delivery et la maintenabilite des produits.",
+          tech: [".NET", "Blazor", "Entity Framework", "Azure", "Vue.js"],
+        },
+        {
+          roleTitle: "Developpeur Back-end .NET",
+          organizationLabel: "TidyUp Technologies",
+          period: "Juin 2023 - Oct. 2023",
+          context:
+            "Plateforme de classement et recherche de contenus numeriques avec composante IA.",
+          valueDelivered:
+            "Construction d'un socle backend durable pour accompagner l'evolution produit et la fiabilite des traitements.",
+          tech: [".NET MVC", ".NET Core", "C#", "Xamarin Forms", "SQL"],
+        },
+        {
+          roleTitle: "Developpeur Back-end .NET",
+          organizationLabel: "UBALDI.com",
+          period: "Avr. 2021 - Juin 2023",
+          context:
+            "Contribution a plusieurs projets internes avec des enjeux de continuite de service et de performance applicative.",
+          valueDelivered:
+            "Fiabilisation du delivery backend et amelioration continue des processus techniques internes.",
+          tech: [".NET", "C#", "API", "SQL Server"],
+        },
+        {
+          roleTitle: "Developpeur Fullstack .NET",
+          organizationLabel: "Regie Eau d'Azur",
+          period: "Sept. 2015 - Avr. 2021",
+          context:
+            "Realisation de solutions applicatives internes sur un cycle long dans des contextes metier varies.",
+          valueDelivered:
+            "Industrialisation progressive des applications et renforcement de la qualite de service pour les utilisateurs finaux.",
+          tech: [".NET", "C#", "SQL", "Architecture applicative"],
+        },
+      ],
+      educationCta: "Voir le parcours de formation",
+    },
+    education: {
+      title: "Formation",
+      subtitle:
+        "Un socle academique solide, complete par une veille continue et une montee en competences pilotee par les besoins terrain.",
+      entries: [
+        {
+          period: "2014 - 2015",
+          title: "Licence Professionnelle IDSE",
+          institution: "IUT Nice Sophia Antipolis",
+          description:
+            "Specialisation en ingenierie logicielle et systemes informatiques, avec une orientation forte vers le developpement applicatif.",
+        },
+        {
+          period: "2012 - 2014",
+          title: "BTS SIO",
+          institution: "Lycee Honore d'Estienne d'Orves",
+          description:
+            "Formation structurante en developpement, bases de donnees et culture projet, ensuite appliquee sur des contextes metier varies.",
+        },
+      ],
+      continuousLearningTitle: "Apprentissage continu",
+      continuousLearningText:
+        "Au-dela du cursus initial, je maintiens une veille active sur l'ecosysteme .NET, l'architecture applicative, le cloud Microsoft et l'integration pragmatique de l'IA.",
+    },
+    projects: {
+      title: "Projets",
+      subtitle:
+        "Quelques cas concrets pour montrer comment je transforme un contexte technique ou metier en resultat exploitable.",
+      items: [
+        {
+          title: "Astreinte et interventions",
+          summary:
+            "Solution metier pour piloter appels d'astreinte, urgences et interventions sur usages bureau et mobile.",
+          context:
+            "Environnement operationnel exigeant, avec fortes contraintes de disponibilite et qualite de service continue.",
+          contribution:
+            "Conception et developpement Fullstack sur socle .NET 7 et ABP, avec architecture orientee domaine.",
+          outcome:
+            "Digitalisation des processus terrain et meilleure reactivite des equipes dans les situations critiques.",
+          tags: [".NET", "C#", "ABP", "DDD", "Azure", "MongoDB"],
+        },
+        {
+          title: "Plateforme backend avec composante IA",
+          summary:
+            "Base applicative pour le rangement, le classement et la recherche de contenus numeriques a forte valeur.",
+          context:
+            "Besoin d'une fondation backend solide pour accompagner dans le temps les evolutions produit et les usages IA.",
+          contribution:
+            "Developpement backend en .NET MVC et .NET Core, structuration des flux techniques et de la persistance.",
+          outcome:
+            "Socle technique durable facilitant la montee en capacite produit et la fiabilite des traitements.",
+          tags: [".NET MVC", ".NET Core", "C#", "SQL", "Architecture"],
+        },
+        {
+          title: "Applications internes d'entreprise",
+          summary:
+            "Plusieurs projets internes menes sur des cycles longs pour soutenir les besoins metiers quotidiens.",
+          context:
+            "Contexte multi-applications avec enjeux de maintenabilite, performance et evolution progressive.",
+          contribution:
+            "Developpement backend/fullstack, maintenance evolutive et amelioration continue de la qualite de delivery.",
+          outcome:
+            "Fiabilisation des processus internes et meilleure continuite de service pour les utilisateurs metiers.",
+          tags: [".NET", "Blazor", "Entity Framework", "SQL Server", "Delivery"],
+          publicLink: "https://c8g.fr",
+        },
+      ],
+      primaryAction: { label: "Discuter de votre projet", href: "#contact" },
+      secondaryAction: { label: "Demander un echange", href: "#contact" },
+    },
+    contact: {
+      title: "Contact",
+      description:
+        "Parlez-moi de ce que vous souhaitez livrer. Je reviens rapidement avec un regard concret sur le besoin, les contraintes et la meilleure trajectoire de mise en oeuvre.",
+      inquiryTypes: [
+        "Creation ou refonte d'application web .NET",
+        "Renfort Fullstack sur produit existant",
+        "Audit technique, cadrage ou acceleration de delivery",
+      ],
+      primaryActionLabel: "Me contacter",
+      copyActionLabel: "Copier l'adresse e-mail",
+      copySuccess: "Adresse e-mail copiee.",
+      copyUnavailable: "Copie non disponible. Utilisez l'adresse e-mail affichee ci-dessous.",
+      copyError: "Impossible de copier l'adresse automatiquement. Copiez-la manuellement.",
+      emailLabel: "Email direct",
+      meta: "Nice, Provence-Alpes-Cote d'Azur | Remote, hybride et sur site",
+      responsePromise: "Reponse rapide, echange simple et pas de tunnel inutile.",
+    },
+    footer: {
+      baseline: "Freelance Fullstack .NET pour des produits web fiables, lisibles et utiles.",
+      availability: "Disponible pour des missions structurelles, des renforts ciblés et des interventions a fort impact.",
+      navigationTitle: "Navigation",
+      links: [
+        { label: "Accueil", href: "#hero" },
+        { label: "Services", href: "#services" },
+        { label: "Projets", href: "#projects" },
+        { label: "Contact", href: "#contact" },
+      ],
+      contactTitle: "Contact",
+      rights: "© 2026 Valentin PASSE. Tous droits reserves.",
+    },
+  },
+  en: {
+    localeName: "EN",
+    switchLocaleLabel: "FR",
+    meta: {
+      title: "Valentin PASSE | Fullstack .NET Freelancer",
+      description:
+        "One-page portfolio of Valentin PASSE, Fullstack .NET freelancer based in Nice. Product delivery, application architecture, and pragmatic AI integration.",
+    },
+    navigation: {
+      items: NAV_IDS.map((item) => ({ id: item.id, label: item.en })),
+      ctaLabel: "Discuss your project",
+      localeSwitcherLabel: "Switch portfolio language",
+    },
+    hero: {
+      eyebrow: "Fullstack .NET freelancer | Nice, remote, hybrid, on-site",
+      name: "Valentin Passe",
+      tagline: "I design reliable web products that stay readable and easy to evolve.",
+      promise:
+        "I work across scoping, fullstack .NET development, delivery quality, and useful AI integration to help teams move faster without creating unnecessary technical debt.",
+      proofPoints: [
+        "A mix of employee and freelance experience to balance product direction with delivery constraints.",
+        "Hands-on expertise in .NET, Blazor, application architecture, and demanding business environments.",
+        "Direct, outcome-driven execution with strong focus on code clarity and end-user value.",
+      ],
+      metrics: [
+        { value: "10+", label: "years of software delivery" },
+        { value: "2", label: "parallel freelance engagements since 2023" },
+        { value: ".NET", label: "core stack to build and scale with confidence" },
+      ],
+      primaryAction: { label: "Discuss your needs", href: "#contact" },
+      secondaryAction: { label: "View projects", href: "#projects" },
+    },
+    about: {
+      title: "About",
+      lead:
+        "As a freelance Fullstack .NET engineer, I help companies turn business needs into robust and usable web products.",
+      paragraphs: [
+        "I work across the whole value chain: scoping, architecture, implementation, quality, and production delivery. The objective is straightforward: ship quickly, cleanly, and without sacrificing maintainability.",
+        "My positioning combines technical rigor, product thinking, and pragmatic AI integration. I value solutions that remain clear, useful, and understandable for the team that will evolve them afterwards.",
+      ],
+      highlights: [
+        {
+          title: "End-to-end execution",
+          description: "From early needs to release, I keep a result-oriented mindset and a clear product overview.",
+        },
+        {
+          title: "Strong fullstack .NET focus",
+          description: "Back-end, APIs, Blazor front-end, and application architecture to avoid dead zones between layers.",
+        },
+        {
+          title: "Pragmatic AI integration",
+          description: "I use AI when it genuinely simplifies a workflow, not as a decorative layer that adds complexity.",
+        },
+      ],
+      principles: ["Design", "Ship", "Stabilize", "Evolve"],
+      primaryAction: { label: "Explore projects", href: "#projects" },
+      secondaryAction: { label: "Get in touch", href: "#contact" },
+    },
+    services: {
+      title: "Services",
+      subtitle:
+        "Three intervention modes to structure a roadmap, strengthen an existing product, or unlock practical AI-driven gains.",
+      items: [
+        {
+          title: "Scoping and technical direction",
+          clientProblem:
+            "The business need is clear, but the solution still lacks enough technical structure to start with confidence.",
+          businessOutcome:
+            "You get clear architecture decisions, a deliverable rollout plan, and a realistic delivery path.",
+          capabilities: ["Scoping workshops", ".NET architecture", "Prioritized roadmap"],
+          ctaTarget: "#contact",
+        },
+        {
+          title: "Fullstack .NET delivery",
+          clientProblem:
+            "Your product must evolve quickly without hurting code clarity, performance, or long-term maintainability.",
+          businessOutcome:
+            "You speed up production delivery with an implementation that is robust, readable, and aligned with real usage.",
+          capabilities: [".NET APIs and back-end", "Blazor interfaces", "Quality and performance"],
+          ctaTarget: "#contact",
+        },
+        {
+          title: "Useful automation and AI",
+          clientProblem:
+            "Teams lose time on repetitive operations and need practical gains without launching an oversized transformation program.",
+          businessOutcome:
+            "You identify high-value automations with restrained AI integration adapted to the business context.",
+          capabilities: ["Workflow audit", "Targeted automation", "Adoption support"],
+          ctaTarget: "#contact",
+        },
+      ],
+    },
+    experience: {
+      title: "Experience",
+      subtitle:
+        "Long-running delivery work in demanding environments, with constant attention to reliability, readability, and business value.",
+      entries: [
+        {
+          roleTitle: "Fullstack .NET Development Engineer",
+          organizationLabel: "SMEG, Monaco",
+          period: "Nov. 2023 - Present",
+          context:
+            "On-call management, emergency, and intervention platform for office and mobile usage.",
+          valueDelivered:
+            "Designed and delivered a reliable system for critical operations with stronger field responsiveness.",
+          tech: [".NET 7", "C#", "ABP", "DDD", "Azure", "Docker", "RabbitMQ", "Redis", "MongoDB"],
+        },
+        {
+          roleTitle: "Fullstack .NET Development Engineer",
+          organizationLabel: "Groupe C8G",
+          period: "Jun. 2023 - Present",
+          context:
+            "Business-oriented web solutions supporting internal operations and daily team efficiency.",
+          valueDelivered:
+            "Delivered fullstack features that improved release speed and long-term product maintainability.",
+          tech: [".NET", "Blazor", "Entity Framework", "Azure", "Vue.js"],
+        },
+        {
+          roleTitle: "Back-end .NET Developer",
+          organizationLabel: "TidyUp Technologies",
+          period: "Jun. 2023 - Oct. 2023",
+          context:
+            "Content organization and search platform with an AI component.",
+          valueDelivered:
+            "Built a durable back-end foundation to support product evolution and processing reliability.",
+          tech: [".NET MVC", ".NET Core", "C#", "Xamarin Forms", "SQL"],
+        },
+        {
+          roleTitle: "Back-end .NET Developer",
+          organizationLabel: "UBALDI.com",
+          period: "Apr. 2021 - Jun. 2023",
+          context:
+            "Contributed to several internal projects with service continuity and performance constraints.",
+          valueDelivered:
+            "Strengthened back-end delivery and continuously improved internal engineering processes.",
+          tech: [".NET", "C#", "API", "SQL Server"],
+        },
+        {
+          roleTitle: "Fullstack .NET Developer",
+          organizationLabel: "Regie Eau d'Azur",
+          period: "Sep. 2015 - Apr. 2021",
+          context:
+            "Built internal business applications over a long cycle across varied operational contexts.",
+          valueDelivered:
+            "Gradually industrialized applications and improved service quality for end users.",
+          tech: [".NET", "C#", "SQL", "Application architecture"],
+        },
+      ],
+      educationCta: "View education",
+    },
+    education: {
+      title: "Education",
+      subtitle:
+        "A solid academic foundation, complemented by continuous learning and skill growth shaped by real delivery work.",
+      entries: [
+        {
+          period: "2014 - 2015",
+          title: "Professional Bachelor's Degree in IDSE",
+          institution: "IUT Nice Sophia Antipolis",
+          description:
+            "Specialized in software engineering and information systems, with a strong focus on application development.",
+        },
+        {
+          period: "2012 - 2014",
+          title: "BTS SIO",
+          institution: "Lycee Honore d'Estienne d'Orves",
+          description:
+            "A structured training path in software development, databases, and project culture applied later in varied business contexts.",
+        },
+      ],
+      continuousLearningTitle: "Continuous learning",
+      continuousLearningText:
+        "Beyond formal education, I actively keep up with the .NET ecosystem, application architecture, Microsoft cloud services, and pragmatic AI integration.",
+    },
+    projects: {
+      title: "Projects",
+      subtitle:
+        "A selection of concrete delivery contexts showing how I turn business or technical constraints into usable outcomes.",
+      items: [
+        {
+          title: "On-call and intervention platform",
+          summary:
+            "Business solution to manage on-call operations, emergencies, and interventions across office and mobile workflows.",
+          context:
+            "Demanding operational environment with high expectations around availability and continuity of service.",
+          contribution:
+            "Designed and developed the product fullstack on a .NET 7 and ABP foundation with domain-oriented architecture.",
+          outcome:
+            "Digitized field processes and improved responsiveness in critical situations.",
+          tags: [".NET", "C#", "ABP", "DDD", "Azure", "MongoDB"],
+        },
+        {
+          title: "Back-end platform with AI component",
+          summary:
+            "Application foundation for organizing, classifying, and searching valuable digital content.",
+          context:
+            "A product context that required a strong back-end basis to support future AI-enabled evolutions.",
+          contribution:
+            "Developed the back-end in .NET MVC and .NET Core while structuring technical flows and persistence.",
+          outcome:
+            "Built a durable technical base supporting product scalability and reliable processing.",
+          tags: [".NET MVC", ".NET Core", "C#", "SQL", "Architecture"],
+        },
+        {
+          title: "Internal business applications",
+          summary:
+            "Several long-cycle internal projects built to support day-to-day business operations.",
+          context:
+            "A multi-application environment with ongoing maintainability, performance, and evolution challenges.",
+          contribution:
+            "Worked on back-end and fullstack delivery, iterative maintenance, and overall delivery quality.",
+          outcome:
+            "Improved internal process reliability and service continuity for business users.",
+          tags: [".NET", "Blazor", "Entity Framework", "SQL Server", "Delivery"],
+          publicLink: "https://c8g.fr",
+        },
+      ],
+      primaryAction: { label: "Discuss your project", href: "#contact" },
+      secondaryAction: { label: "Book an intro call", href: "#contact" },
+    },
+    contact: {
+      title: "Contact",
+      description:
+        "Tell me what you want to ship. I will get back to you quickly with a concrete view of the need, the constraints, and the most relevant delivery path.",
+      inquiryTypes: [
+        "New or redesigned .NET web application",
+        "Fullstack reinforcement on an existing product",
+        "Technical review, scoping, or delivery acceleration",
+      ],
+      primaryActionLabel: "Get in touch",
+      copyActionLabel: "Copy email address",
+      copySuccess: "Email address copied.",
+      copyUnavailable: "Copy is unavailable. Please use the email address displayed below.",
+      copyError: "The address could not be copied automatically. Please copy it manually.",
+      emailLabel: "Direct email",
+      meta: "Nice, Provence-Alpes-Cote d'Azur | Remote, hybrid, and on-site",
+      responsePromise: "Fast reply, direct conversation, no unnecessary funnel.",
+    },
+    footer: {
+      baseline: "Fullstack .NET freelancer for reliable, readable, and useful web products.",
+      availability: "Available for structural projects, focused reinforcement, and high-impact interventions.",
+      navigationTitle: "Navigation",
+      links: [
+        { label: "Home", href: "#hero" },
+        { label: "Services", href: "#services" },
+        { label: "Projects", href: "#projects" },
+        { label: "Contact", href: "#contact" },
+      ],
+      contactTitle: "Contact",
+      rights: "© 2026 Valentin PASSE. All rights reserved.",
+    },
+  },
+};
+
+export function getPortfolioContent(locale: PortfolioLocale): PortfolioContent {
+  return portfolioContent[locale] || portfolioContent.fr;
+}
+
+export const portfolioEmail = EMAIL;

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,32 +1,23 @@
-// Libs
-import type { AppProps } from 'next/app'
+import type { AppProps } from "next/app";
+import { Manrope, Space_Grotesk } from "next/font/google";
+import "../styles/globals.css";
 
-// Components
-// import Layout from '../components/layout/Layout';
-import { useEffect } from 'react';
+const bodyFont = Manrope({
+  subsets: ["latin"],
+  variable: "--font-body",
+  display: "swap",
+});
 
-//CSS Module
-import '../styles/globals.css'
-import 'bootstrap/dist/css/bootstrap.css'
+const displayFont = Space_Grotesk({
+  subsets: ["latin"],
+  variable: "--font-display",
+  display: "swap",
+});
 
 export default function App({ Component, pageProps }: AppProps) {
-  useEffect(() => {
-    require('../node_modules/bootstrap/dist/js/bootstrap.bundle.js');
-  }, []);
-
-  return <Component {...pageProps} />
+  return (
+    <div className={`${bodyFont.variable} ${displayFont.variable}`}>
+      <Component {...pageProps} />
+    </div>
+  );
 }
-
-// export default function App({ Component, pageProps }: AppProps) {
-// useEffect(() => {
-//   require('../node_modules/bootstrap/dist/js/bootstrap.bundle.js');
-// }, []);
-
-//   return (
-//     <>
-//       <Layout>
-//           <Component {...pageProps} />
-//       </Layout>
-//     </>
-//   );
-// }

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -1,0 +1,33 @@
+import Document, { Head, Html, Main, NextScript, DocumentContext } from "next/document";
+
+type PortfolioDocumentProps = {
+  locale: "fr" | "en";
+};
+
+class PortfolioDocument extends Document<PortfolioDocumentProps> {
+  static async getInitialProps(ctx: DocumentContext) {
+    const initialProps = await Document.getInitialProps(ctx);
+    const locale = ctx.pathname.startsWith("/en") ? "en" : "fr";
+
+    return {
+      ...initialProps,
+      locale,
+    };
+  }
+
+  render() {
+    const locale = this.props.locale || "fr";
+
+    return (
+      <Html lang={locale}>
+        <Head />
+        <body>
+          <Main />
+          <NextScript />
+        </body>
+      </Html>
+    );
+  }
+}
+
+export default PortfolioDocument;

--- a/pages/en.tsx
+++ b/pages/en.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { HomePage } from "../components/homePage";
 
-export default function Home() {
-  return <HomePage locale="fr" />;
+export default function HomeEn() {
+  return <HomePage locale="en" />;
 }

--- a/styles/Home.module.css
+++ b/styles/Home.module.css
@@ -1,129 +1,22 @@
-.container {
-  padding: 0 2rem;
+.page {
+  position: relative;
 }
 
-.main {
-  min-height: 100vh;
-  padding: 4rem 0;
-  flex: 1;
+.container {
+  padding: 0 1.25rem 4rem;
+}
+
+.stack {
+  position: relative;
+  max-width: 1180px;
+  margin: 0 auto;
   display: flex;
   flex-direction: column;
-  justify-content: center;
-  align-items: center;
+  gap: 0;
 }
 
-.footer {
-  display: flex;
-  flex: 1;
-  padding: 2rem 0;
-  border-top: 1px solid #eaeaea;
-  justify-content: center;
-  align-items: center;
-}
-
-.footer a {
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  flex-grow: 1;
-}
-
-.title a {
-  color: #0070f3;
-  text-decoration: none;
-}
-
-.title a:hover,
-.title a:focus,
-.title a:active {
-  text-decoration: underline;
-}
-
-.title {
-  margin: 0;
-  line-height: 1.15;
-  font-size: 4rem;
-}
-
-.title,
-.description {
-  text-align: center;
-}
-
-.description {
-  margin: 4rem 0;
-  line-height: 1.5;
-  font-size: 1.5rem;
-}
-
-.code {
-  background: #fafafa;
-  border-radius: 5px;
-  padding: 0.75rem;
-  font-size: 1.1rem;
-  font-family: Menlo, Monaco, Lucida Console, Liberation Mono, DejaVu Sans Mono,
-    Bitstream Vera Sans Mono, Courier New, monospace;
-}
-
-.grid {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  flex-wrap: wrap;
-  max-width: 800px;
-}
-
-.card {
-  margin: 1rem;
-  padding: 1.5rem;
-  text-align: left;
-  color: inherit;
-  text-decoration: none;
-  border: 1px solid #eaeaea;
-  border-radius: 10px;
-  transition: color 0.15s ease, border-color 0.15s ease;
-  max-width: 300px;
-}
-
-.card:hover,
-.card:focus,
-.card:active {
-  color: #0070f3;
-  border-color: #0070f3;
-}
-
-.card h2 {
-  margin: 0 0 1rem 0;
-  font-size: 1.5rem;
-}
-
-.card p {
-  margin: 0;
-  font-size: 1.25rem;
-  line-height: 1.5;
-}
-
-.logo {
-  height: 1em;
-  margin-left: 0.5rem;
-}
-
-@media (max-width: 600px) {
-  .grid {
-    width: 100%;
-    flex-direction: column;
-  }
-}
-
-@media (prefers-color-scheme: dark) {
-  .card,
-  .footer {
-    border-color: #222;
-  }
-  .code {
-    background: #111;
-  }
-  .logo img {
-    filter: invert(1);
+@media (max-width: 700px) {
+  .container {
+    padding: 0 0.85rem 3rem;
   }
 }

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,9 +1,38 @@
+:root {
+  --font-body: "Manrope", sans-serif;
+  --font-display: "Space Grotesk", sans-serif;
+  --color-ink: #09111b;
+  --color-deep: #0d1724;
+  --color-surface: #f4f7fb;
+  --color-surface-strong: #ffffff;
+  --color-line: rgba(148, 163, 184, 0.22);
+  --color-text: #102033;
+  --color-text-muted: #506174;
+  --color-highlight: #2f6bff;
+  --color-highlight-soft: #dbeafe;
+  --color-accent: #c68b59;
+  --shadow-soft: 0 16px 40px rgba(15, 23, 42, 0.08);
+  --shadow-strong: 0 28px 70px rgba(2, 8, 23, 0.18);
+  --radius-xl: 24px;
+  --radius-lg: 18px;
+}
+
 html,
 body {
   padding: 0;
   margin: 0;
-  font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Oxygen,
-    Ubuntu, Cantarell, Fira Sans, Droid Sans, Helvetica Neue, sans-serif;
+  font-family: var(--font-body);
+  color: var(--color-text);
+  background: var(--color-surface);
+}
+
+html {
+  scroll-behavior: smooth;
+}
+
+body {
+  min-height: 100vh;
+  text-rendering: optimizeLegibility;
 }
 
 a {
@@ -11,24 +40,22 @@ a {
   text-decoration: none;
 }
 
-html {
-  scroll-behavior: smooth;
+img {
+  max-width: 100%;
+}
+
+main {
+  display: block;
 }
 
 section[id] {
-  scroll-margin-top: 5.5rem;
+  scroll-margin-top: 7rem;
 }
 
 * {
   box-sizing: border-box;
 }
 
-@media (prefers-color-scheme: dark) {
-  html {
-    color-scheme: dark;
-  }
-  body {
-    color: white;
-    background: black;
-  }
+*::selection {
+  background: rgba(47, 107, 255, 0.2);
 }

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -11,6 +11,14 @@ a {
   text-decoration: none;
 }
 
+html {
+  scroll-behavior: smooth;
+}
+
+section[id] {
+  scroll-margin-top: 5.5rem;
+}
+
 * {
   box-sizing: border-box;
 }


### PR DESCRIPTION
## Summary
Implements issue #11: one-page navigation for the portfolio.

## What was added
- Refactored header navigation to canonical one-page anchors: `#hero`, `#about`, `#services`, `#skills`, `#experience`, `#projects`, `#contact`
- Active section highlighting based on visible section while scrolling
- Mobile menu behavior with proper open/close state and auto-close after item click
- Persistent conversion actions in header (`Contact`, `CV`)
- Fallback handling when an anchor target or CV download is unavailable
- Added `id="hero"` to hero section for canonical navigation target
- Added smooth scrolling and section offset handling for sticky header in global styles

## Files changed
- `components/headerCustom/headerCustom.tsx`
- `components/headerCustom/headerCustom.module.scss`
- `components/heroSection/heroSection.tsx`
- `styles/globals.css`

## Validation
- `npm run build` ✅
- `npm test -- --runInBand` ✅

## Related
- Closes #11