### PR TITLE
feat(analytics): add Vercel Analytics

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "valentinpasse-nextjs",
       "version": "0.1.0",
       "dependencies": {
+        "@vercel/analytics": "^2.0.1",
         "next": "^16.2.3",
         "react": "^19.2.4",
         "react-dom": "^19.2.4"
@@ -3321,6 +3322,48 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@vercel/analytics": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@vercel/analytics/-/analytics-2.0.1.tgz",
+      "integrity": "sha512-MTQG6V9qQrt1tsDeF+2Uoo5aPjqbVPys1xvnIftXSJYG2SrwXRHnqEvVoYID7BTruDz4lCd2Z7rM1BdkUehk2g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@remix-run/react": "^2",
+        "@sveltejs/kit": "^1 || ^2",
+        "next": ">= 13",
+        "nuxt": ">= 3",
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "svelte": ">= 4",
+        "vue": "^3",
+        "vue-router": "^4"
+      },
+      "peerDependenciesMeta": {
+        "@remix-run/react": {
+          "optional": true
+        },
+        "@sveltejs/kit": {
+          "optional": true
+        },
+        "next": {
+          "optional": true
+        },
+        "nuxt": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        },
+        "vue-router": {
+          "optional": true
+        }
+      }
     },
     "node_modules/acorn": {
       "version": "8.16.0",
@@ -12214,6 +12257,12 @@
       "integrity": "sha512-lrW200hZdbfRtztbygyaq/6jP6AKE8qQN2KvPcJ+x7wiD038YtnYtZ82IMNJ69GJibV7bwL3y9FgK+5w/pYt6g==",
       "dev": true,
       "optional": true
+    },
+    "@vercel/analytics": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@vercel/analytics/-/analytics-2.0.1.tgz",
+      "integrity": "sha512-MTQG6V9qQrt1tsDeF+2Uoo5aPjqbVPys1xvnIftXSJYG2SrwXRHnqEvVoYID7BTruDz4lCd2Z7rM1BdkUehk2g==",
+      "requires": {}
     },
     "acorn": {
       "version": "8.16.0",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "build:og": "node scripts/build-og-image.mjs"
   },
   "dependencies": {
+    "@vercel/analytics": "^2.0.1",
     "next": "^16.2.3",
     "react": "^19.2.4",
     "react-dom": "^19.2.4"

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,6 +1,7 @@
 import type { AppProps } from "next/app";
 import { useRouter } from "next/router";
 import { Archivo, Space_Grotesk } from "next/font/google";
+import { Analytics } from "@vercel/analytics/next";
 import { GoogleAnalytics } from "../components/googleAnalytics";
 import { CookieConsentBanner } from "../components/cookieConsent";
 import "../styles/globals.css";
@@ -26,6 +27,7 @@ export default function App({ Component, pageProps }: AppProps) {
       <GoogleAnalytics />
       <Component {...pageProps} />
       <CookieConsentBanner locale={locale} />
+      <Analytics />
     </div>
   );
 }


### PR DESCRIPTION
## Résumé
Ajoute le composant `<Analytics />` de `@vercel/analytics/next` dans `pages/_app.tsx` pour collecter les statistiques de fréquentation côté Vercel, en complément de Google Analytics 4.

## Détails
- Nouvelle dépendance : `@vercel/analytics`
- Contrairement à GA4, Vercel Web Analytics est **sans cookie** → pas de consentement requis, le composant est toujours monté.
- Les données apparaîtront dans l'onglet **Analytics** du projet Vercel après déploiement (Web Analytics doit être activé dans les settings du projet).

## Vérifications
- ✅ `tsc --noEmit`
- ✅ `eslint .`
- ✅ `next build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)