### PR TITLE
feat(legal): pages Mentions légales bilingues (FR/EN)

### DIFF
--- a/components/footerCustom/footerCustom.module.scss
+++ b/components/footerCustom/footerCustom.module.scss
@@ -71,6 +71,18 @@
 	line-height: 1.6;
 }
 
+.legalLink {
+	display: inline-block;
+	margin-top: 0.65rem;
+	color: var(--color-on-dark-muted);
+	text-decoration: underline;
+	text-underline-offset: 2px;
+}
+
+.legalLink:hover {
+	color: var(--color-on-dark);
+}
+
 @media (max-width: 900px) {
 	.container {
 		grid-template-columns: 1fr;

--- a/components/footerCustom/footerCustom.tsx
+++ b/components/footerCustom/footerCustom.tsx
@@ -43,6 +43,9 @@ export function FooterCustom({ locale }: FooterCustomProps) {
             {portfolioEmail}
           </a>
           <p className={styles.rights}>{content.rights}</p>
+          <Link href={content.legalLink.href} className={styles.legalLink}>
+            {content.legalLink.label}
+          </Link>
         </div>
       </div>
     </footer>

--- a/components/footerCustom/footerCustom.tsx
+++ b/components/footerCustom/footerCustom.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import Link from "next/link";
 import Image from "next/image";
 import LogoHeader from "../../public/images/header/logo.webp";
-import { PortfolioLocale, getPortfolioContent, portfolioEmail } from "../../content/portfolioContent";
+import { PortfolioLocale, getPortfolioContent, portfolioEmail, homePath } from "../../content/portfolioContent";
 import styles from "./footerCustom.module.scss";
 
 type FooterCustomProps = {
@@ -16,7 +16,7 @@ export function FooterCustom({ locale }: FooterCustomProps) {
     <footer className={styles.footer}>
       <div className={styles.container}>
         <div className={styles.brandColumn}>
-          <Link href={locale === "en" ? "/en" : "/"} className={styles.brandLink}>
+          <Link href={homePath(locale)} className={styles.brandLink}>
             <Image src={LogoHeader} width={56} height={66} alt="Logo du portfolio de Valentin PASSE" />
             <div>
               <p className={styles.brandTitle}>Valentin Passe</p>

--- a/components/headerCustom/headerCustom.tsx
+++ b/components/headerCustom/headerCustom.tsx
@@ -6,9 +6,16 @@ import styles from "./headerCustom.module.scss";
 
 type HeaderCustomProps = {
   locale: PortfolioLocale;
+  /**
+   * When true, the header belongs to a secondary page (not the one-page home):
+   * nav links navigate back to the home sections instead of scrolling in place.
+   */
+  secondary?: boolean;
+  /** Overrides the locale switcher target (used by secondary pages). */
+  localeSwitchHref?: string;
 };
 
-export function HeaderCustom({ locale }: HeaderCustomProps) {
+export function HeaderCustom({ locale, secondary = false, localeSwitchHref }: HeaderCustomProps) {
   const content = React.useMemo(() => getPortfolioContent(locale), [locale]);
   const navItems = React.useMemo(
     () => content.navigation.items.map((item) => ({ ...item, route: `#${item.id}` })),
@@ -20,6 +27,8 @@ export function HeaderCustom({ locale }: HeaderCustomProps) {
   const [isScrolled, setIsScrolled] = React.useState<boolean>(false);
   const [notice, setNotice] = React.useState<string>("");
   const otherLocaleHref = `${locale === "fr" ? "/en" : "/"}#${activeSectionId || "hero"}`;
+  const homeBase = locale === "en" ? "/en" : "/";
+  const resolvedLocaleSwitchHref = localeSwitchHref ?? otherLocaleHref;
   // Over the hero the header stays transparent so the 3D scene shows through;
   // a solid backdrop appears once scrolled (or while the mobile menu is open)
   // to keep the nav readable above the lighter content sections.
@@ -113,7 +122,11 @@ export function HeaderCustom({ locale }: HeaderCustomProps) {
   return (
     <header className={`${styles.header} ${hasBackdrop ? styles.headerScrolled : ""}`.trim()}>
       <nav className={styles.nav} aria-label={content.navigation.mainNavAriaLabel}>
-        <a href="#hero" className={styles.brand} onClick={(event) => handleAnchorNavigation(event, "#hero", "hero")}>
+        <a
+          href={secondary ? homeBase : "#hero"}
+          className={styles.brand}
+          onClick={secondary ? undefined : (event) => handleAnchorNavigation(event, "#hero", "hero")}
+        >
           <Image src={Logo} width={44} height={52} alt="Logo Valentin PASSE" />
           <span className={styles.brandText}>
             <span className={styles.brandTitle}>Valentin Passe</span>
@@ -142,10 +155,10 @@ export function HeaderCustom({ locale }: HeaderCustomProps) {
             {navItems.map((item) => (
               <li key={item.id}>
                 <a
-                  href={item.route}
-                  className={`${styles.navLink} ${activeSectionId === item.id ? styles.navLinkActive : ""}`.trim()}
-                  aria-current={activeSectionId === item.id ? "page" : undefined}
-                  onClick={(event) => handleAnchorNavigation(event, item.route, item.id)}
+                  href={secondary ? `${homeBase}${item.route}` : item.route}
+                  className={`${styles.navLink} ${!secondary && activeSectionId === item.id ? styles.navLinkActive : ""}`.trim()}
+                  aria-current={!secondary && activeSectionId === item.id ? "page" : undefined}
+                  onClick={secondary ? undefined : (event) => handleAnchorNavigation(event, item.route, item.id)}
                 >
                   {item.label}
                 </a>
@@ -155,16 +168,16 @@ export function HeaderCustom({ locale }: HeaderCustomProps) {
 
           <div className={styles.utilityGroup}>
             <a
-              href={otherLocaleHref}
+              href={resolvedLocaleSwitchHref}
               className={styles.localeSwitch}
               aria-label={content.navigation.localeSwitcherLabel}
             >
               {content.switchLocaleLabel}
             </a>
             <a
-              href="#contact"
+              href={secondary ? `${homeBase}#contact` : "#contact"}
               className={styles.contactCta}
-              onClick={(event) => handleAnchorNavigation(event, "#contact", "contact")}
+              onClick={secondary ? undefined : (event) => handleAnchorNavigation(event, "#contact", "contact")}
             >
               {content.navigation.ctaLabel}
             </a>

--- a/components/headerCustom/headerCustom.tsx
+++ b/components/headerCustom/headerCustom.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import Image from "next/image";
 import Logo from "../../public/images/header/logo.webp";
-import { PortfolioLocale, getPortfolioContent } from "../../content/portfolioContent";
+import { PortfolioLocale, getPortfolioContent, homePath } from "../../content/portfolioContent";
 import styles from "./headerCustom.module.scss";
 
 type HeaderCustomProps = {
@@ -27,7 +27,7 @@ export function HeaderCustom({ locale, secondary = false, localeSwitchHref }: He
   const [isScrolled, setIsScrolled] = React.useState<boolean>(false);
   const [notice, setNotice] = React.useState<string>("");
   const otherLocaleHref = `${locale === "fr" ? "/en" : "/"}#${activeSectionId || "hero"}`;
-  const homeBase = locale === "en" ? "/en" : "/";
+  const homeBase = homePath(locale);
   const resolvedLocaleSwitchHref = localeSwitchHref ?? otherLocaleHref;
   // Over the hero the header stays transparent so the 3D scene shows through;
   // a solid backdrop appears once scrolled (or while the mobile menu is open)

--- a/components/headerCustom/headerCustom.tsx
+++ b/components/headerCustom/headerCustom.tsx
@@ -31,8 +31,10 @@ export function HeaderCustom({ locale, secondary = false, localeSwitchHref }: He
   const resolvedLocaleSwitchHref = localeSwitchHref ?? otherLocaleHref;
   // Over the hero the header stays transparent so the 3D scene shows through;
   // a solid backdrop appears once scrolled (or while the mobile menu is open)
-  // to keep the nav readable above the lighter content sections.
-  const hasBackdrop = isScrolled || isMenuOpen;
+  // to keep the nav readable above the lighter content sections. Secondary
+  // pages (e.g. legal notice) have no dark hero, so the backdrop is always on
+  // to keep the light-on-dark nav legible against their light background.
+  const hasBackdrop = isScrolled || isMenuOpen || secondary;
 
   React.useEffect(() => {
     if (typeof window === "undefined") {

--- a/components/layout/layout.tsx
+++ b/components/layout/layout.tsx
@@ -5,13 +5,30 @@ import { FooterCustom } from "../footerCustom";
 import { PortfolioLocale, portfolioEmail } from "../../content/portfolioContent";
 import styles from "./layout.module.scss";
 
+type LocaleAlternates = {
+    fr: string;
+    en: string;
+};
+
 type LayoutProps = {
     children: ReactNode;
     locale: PortfolioLocale;
     title?: string;
     description?: string;
     canonicalPath?: string;
+    /**
+     * Paths (per locale) of the current page's language variants. Drives the
+     * hreflang links and the header locale switcher. Defaults to the home pages.
+     */
+    localeAlternates?: LocaleAlternates;
+    /**
+     * Secondary pages (e.g. legal notice) are not the one-page home, so the
+     * header navigates back to the home sections instead of scrolling in place.
+     */
+    secondary?: boolean;
 };
+
+const DEFAULT_LOCALE_ALTERNATES: LocaleAlternates = { fr: "/", en: "/en" };
 
 const SITE_URL = (process.env.NEXT_PUBLIC_SITE_URL || "https://www.valentin-passe.com").replace(/\/+$/, "");
 const OG_IMAGE_PATH = "/og-image.jpg";
@@ -36,15 +53,21 @@ export function Layout({
     title,
     description,
     canonicalPath = "/",
+    localeAlternates = DEFAULT_LOCALE_ALTERNATES,
+    secondary = false,
 }: LayoutProps) {
     const resolvedTitle = title ?? DEFAULT_TITLES[locale];
     const resolvedDescription = description ?? DEFAULT_DESCRIPTIONS[locale];
     const ogLocale = locale === "en" ? "en_US" : "fr_FR";
     const alternateLocale = locale === "en" ? "fr_FR" : "en_US";
-    const canonicalUrl = `${SITE_URL}${canonicalPath === "/" ? "" : canonicalPath}`;
+    const toAbsolute = (path: string) => `${SITE_URL}${path === "/" ? "" : path}`;
+    const canonicalUrl = toAbsolute(canonicalPath);
     const ogImageUrl = `${SITE_URL}${OG_IMAGE_PATH}`;
-    const frUrl = SITE_URL;
-    const enUrl = `${SITE_URL}/en`;
+    const frUrl = toAbsolute(localeAlternates.fr);
+    const enUrl = toAbsolute(localeAlternates.en);
+    // On secondary pages the header switches language by jumping to the other
+    // locale's variant of this same page rather than the home root.
+    const localeSwitchHref = locale === "fr" ? localeAlternates.en : localeAlternates.fr;
 
     const jsonLdPerson = {
         "@context": "https://schema.org",
@@ -115,7 +138,11 @@ export function Layout({
                 {locale === "en" ? "Skip to content" : "Aller au contenu"}
             </a>
 
-            <HeaderCustom locale={locale} />
+            <HeaderCustom
+                locale={locale}
+                secondary={secondary}
+                localeSwitchHref={secondary ? localeSwitchHref : undefined}
+            />
             <div className={styles.content}>{children}</div>
             <FooterCustom locale={locale} />
         </div>

--- a/components/legalNotice/index.tsx
+++ b/components/legalNotice/index.tsx
@@ -1,0 +1,1 @@
+export * from "./legalNotice";

--- a/components/legalNotice/legalNotice.module.scss
+++ b/components/legalNotice/legalNotice.module.scss
@@ -1,0 +1,96 @@
+.page {
+  position: relative;
+  background: var(--color-background);
+}
+
+.container {
+  max-width: 760px;
+  margin: 0 auto;
+  padding: 8rem 1.25rem 5rem;
+  color: var(--color-text);
+}
+
+.backLink {
+  display: inline-block;
+  margin-bottom: 1.75rem;
+  color: var(--color-accent-strong);
+  font-weight: 600;
+}
+
+.backLink:hover {
+  text-decoration: underline;
+}
+
+.title {
+  margin: 0;
+  font-family: var(--font-display);
+  font-size: clamp(1.9rem, 4vw, 2.6rem);
+  font-weight: 700;
+  color: var(--color-foreground);
+}
+
+.updated {
+  margin: 0.5rem 0 2.5rem;
+  color: var(--color-text-muted);
+  font-size: 0.9rem;
+}
+
+.section {
+  padding: 1.75rem 0;
+  border-top: 1px solid var(--color-border);
+}
+
+.heading {
+  margin: 0 0 1rem;
+  font-family: var(--font-display);
+  font-size: 1.15rem;
+  font-weight: 700;
+  color: var(--color-foreground);
+}
+
+.rows {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.row {
+  display: grid;
+  grid-template-columns: minmax(0, 16rem) 1fr;
+  gap: 0.5rem 1.5rem;
+  margin: 0;
+  line-height: 1.6;
+}
+
+.rowLabel {
+  color: var(--color-text-muted);
+  font-weight: 600;
+}
+
+.rowValue {
+  color: var(--color-text);
+  word-break: break-word;
+}
+
+.rowLink {
+  color: var(--color-accent-strong);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.paragraph {
+  margin: 0;
+  line-height: 1.75;
+  color: var(--color-text);
+}
+
+@media (max-width: 640px) {
+  .container {
+    padding: 7rem 1rem 4rem;
+  }
+
+  .row {
+    grid-template-columns: 1fr;
+    gap: 0.15rem;
+  }
+}

--- a/components/legalNotice/legalNotice.tsx
+++ b/components/legalNotice/legalNotice.tsx
@@ -1,0 +1,68 @@
+import React from "react";
+import Link from "next/link";
+import { Layout } from "../layout";
+import { PortfolioLocale, getPortfolioContent } from "../../content/portfolioContent";
+import styles from "./legalNotice.module.scss";
+
+type LegalNoticePageProps = {
+  locale: PortfolioLocale;
+};
+
+// Language variants of this page, shared by the FR (/mentions-legales) and
+// EN (/legal-notice) routes so hreflang and the locale switcher stay correct.
+const LOCALE_ALTERNATES = { fr: "/mentions-legales", en: "/legal-notice" };
+
+export function LegalNoticePage({ locale }: LegalNoticePageProps) {
+  const legal = getPortfolioContent(locale).legal;
+  const homeHref = locale === "en" ? "/en" : "/";
+  const canonicalPath = locale === "en" ? "/legal-notice" : "/mentions-legales";
+
+  return (
+    <Layout
+      locale={locale}
+      title={legal.metaTitle}
+      description={legal.metaDescription}
+      canonicalPath={canonicalPath}
+      localeAlternates={LOCALE_ALTERNATES}
+      secondary
+    >
+      <main id="main-content" className={styles.page}>
+        <article className={styles.container}>
+          <Link href={homeHref} className={styles.backLink}>
+            {legal.backHomeLabel}
+          </Link>
+          <h1 className={styles.title}>{legal.pageTitle}</h1>
+          <p className={styles.updated}>{legal.lastUpdated}</p>
+
+          {legal.sections.map((section) => (
+            <section key={section.heading} className={styles.section}>
+              <h2 className={styles.heading}>{section.heading}</h2>
+              <div className={styles.rows}>
+                {section.rows.map((row, index) =>
+                  row.label ? (
+                    <p key={index} className={styles.row}>
+                      <span className={styles.rowLabel}>{row.label}</span>
+                      <span className={styles.rowValue}>
+                        {row.href ? (
+                          <a href={row.href} className={styles.rowLink}>
+                            {row.value}
+                          </a>
+                        ) : (
+                          row.value
+                        )}
+                      </span>
+                    </p>
+                  ) : (
+                    <p key={index} className={styles.paragraph}>
+                      {row.value}
+                    </p>
+                  )
+                )}
+              </div>
+            </section>
+          ))}
+        </article>
+      </main>
+    </Layout>
+  );
+}

--- a/components/legalNotice/legalNotice.tsx
+++ b/components/legalNotice/legalNotice.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import Link from "next/link";
 import { Layout } from "../layout";
-import { PortfolioLocale, getPortfolioContent } from "../../content/portfolioContent";
+import { PortfolioLocale, getPortfolioContent, homePath } from "../../content/portfolioContent";
 import styles from "./legalNotice.module.scss";
 
 type LegalNoticePageProps = {
@@ -14,8 +14,8 @@ const LOCALE_ALTERNATES = { fr: "/mentions-legales", en: "/legal-notice" };
 
 export function LegalNoticePage({ locale }: LegalNoticePageProps) {
   const legal = getPortfolioContent(locale).legal;
-  const homeHref = locale === "en" ? "/en" : "/";
-  const canonicalPath = locale === "en" ? "/legal-notice" : "/mentions-legales";
+  const homeHref = homePath(locale);
+  const canonicalPath = LOCALE_ALTERNATES[locale];
 
   return (
     <Layout
@@ -38,9 +38,9 @@ export function LegalNoticePage({ locale }: LegalNoticePageProps) {
             <section key={section.heading} className={styles.section}>
               <h2 className={styles.heading}>{section.heading}</h2>
               <div className={styles.rows}>
-                {section.rows.map((row, index) =>
+                {section.rows.map((row) =>
                   row.label ? (
-                    <p key={index} className={styles.row}>
+                    <p key={row.label} className={styles.row}>
                       <span className={styles.rowLabel}>{row.label}</span>
                       <span className={styles.rowValue}>
                         {row.href ? (
@@ -53,7 +53,7 @@ export function LegalNoticePage({ locale }: LegalNoticePageProps) {
                       </span>
                     </p>
                   ) : (
-                    <p key={index} className={styles.paragraph}>
+                    <p key={row.value} className={styles.paragraph}>
                       {row.value}
                     </p>
                   )

--- a/content/portfolioContent.ts
+++ b/content/portfolioContent.ts
@@ -59,6 +59,26 @@ type FooterLink = {
   href: string;
 };
 
+type LegalRow = {
+  label?: string;
+  value: string;
+  href?: string;
+};
+
+type LegalSection = {
+  heading: string;
+  rows: LegalRow[];
+};
+
+type LegalContent = {
+  metaTitle: string;
+  metaDescription: string;
+  pageTitle: string;
+  lastUpdated: string;
+  backHomeLabel: string;
+  sections: LegalSection[];
+};
+
 export type PortfolioContent = {
   localeName: string;
   switchLocaleLabel: string;
@@ -154,7 +174,9 @@ export type PortfolioContent = {
     links: FooterLink[];
     contactTitle: string;
     rights: string;
+    legalLink: FooterLink;
   };
+  legal: LegalContent;
 };
 
 // The `educations` section is intentionally excluded from NAV_IDS to keep the
@@ -517,6 +539,81 @@ export const portfolioContent: Record<PortfolioLocale, PortfolioContent> = {
       ],
       contactTitle: "Contact",
       rights: "© 2026 Valentin PASSE. Tous droits réservés.",
+      legalLink: { label: "Mentions légales", href: "/mentions-legales" },
+    },
+    legal: {
+      metaTitle: "Mentions légales | Valentin PASSE",
+      metaDescription:
+        "Mentions légales du site de Valentin PASSE, développeur Fullstack .NET freelance (micro-entreprise) basé à Nice.",
+      pageTitle: "Mentions légales",
+      lastUpdated: "Dernière mise à jour : juin 2026",
+      backHomeLabel: "← Retour à l'accueil",
+      sections: [
+        {
+          heading: "Éditeur du site",
+          rows: [
+            { label: "Éditeur", value: "Valentin PASSE" },
+            { label: "Statut", value: "Entrepreneur individuel (micro-entreprise)" },
+            { label: "SIREN", value: "947 577 623" },
+            { label: "N° de TVA intracommunautaire", value: "FR53947577623" },
+            { label: "Localisation", value: "Nice (06200), France" },
+            {
+              label: "E-mail",
+              value: "passe.valentin@gmail.com",
+              href: "mailto:passe.valentin@gmail.com",
+            },
+            { label: "Directeur de la publication", value: "Valentin PASSE" },
+          ],
+        },
+        {
+          heading: "Hébergement",
+          rows: [
+            { value: "Le site est hébergé par Vercel Inc." },
+            { label: "Adresse", value: "340 S Lemon Ave #4133, Walnut, CA 91789, États-Unis" },
+            { label: "Site web", value: "vercel.com", href: "https://vercel.com" },
+          ],
+        },
+        {
+          heading: "Propriété intellectuelle",
+          rows: [
+            {
+              value:
+                "L'ensemble des contenus de ce site (textes, structure, éléments graphiques et code) est, sauf mention contraire, la propriété de Valentin PASSE. Toute reproduction, représentation ou diffusion, totale ou partielle, sans autorisation préalable est interdite.",
+            },
+          ],
+        },
+        {
+          heading: "Données personnelles",
+          rows: [
+            {
+              value:
+                "Ce site ne propose pas de formulaire de collecte. Les seules données traitées sont celles que vous transmettez volontairement par e-mail, utilisées uniquement pour répondre à votre demande.",
+            },
+            {
+              value:
+                "Conformément au RGPD et à la loi « Informatique et Libertés », vous disposez d'un droit d'accès, de rectification et de suppression des données vous concernant. Pour l'exercer, écrivez à passe.valentin@gmail.com.",
+            },
+          ],
+        },
+        {
+          heading: "Cookies et mesure d'audience",
+          rows: [
+            {
+              value:
+                "Des outils de mesure d'audience (Vercel Analytics et Google Analytics) peuvent déposer des cookies à des fins statistiques. Ils ne sont activés qu'après votre consentement, recueilli via le bandeau prévu à cet effet, et vous pouvez modifier votre choix à tout moment.",
+            },
+          ],
+        },
+        {
+          heading: "Responsabilité",
+          rows: [
+            {
+              value:
+                "Les informations diffusées sur ce site sont fournies à titre indicatif et peuvent évoluer. Valentin PASSE s'efforce d'en assurer l'exactitude mais ne saurait être tenu responsable des erreurs, d'une indisponibilité du site ou de l'usage qui en est fait.",
+            },
+          ],
+        },
+      ],
     },
   },
   en: {
@@ -860,6 +957,81 @@ export const portfolioContent: Record<PortfolioLocale, PortfolioContent> = {
       ],
       contactTitle: "Contact",
       rights: "© 2026 Valentin PASSE. All rights reserved.",
+      legalLink: { label: "Legal notice", href: "/legal-notice" },
+    },
+    legal: {
+      metaTitle: "Legal Notice | Valentin PASSE",
+      metaDescription:
+        "Legal notice for the website of Valentin PASSE, freelance Fullstack .NET developer (sole trader) based in Nice, France.",
+      pageTitle: "Legal Notice",
+      lastUpdated: "Last updated: June 2026",
+      backHomeLabel: "← Back to home",
+      sections: [
+        {
+          heading: "Site publisher",
+          rows: [
+            { label: "Publisher", value: "Valentin PASSE" },
+            { label: "Status", value: "Sole trader (French micro-entreprise)" },
+            { label: "SIREN", value: "947 577 623" },
+            { label: "EU VAT number", value: "FR53947577623" },
+            { label: "Location", value: "Nice (06200), France" },
+            {
+              label: "Email",
+              value: "passe.valentin@gmail.com",
+              href: "mailto:passe.valentin@gmail.com",
+            },
+            { label: "Publication director", value: "Valentin PASSE" },
+          ],
+        },
+        {
+          heading: "Hosting",
+          rows: [
+            { value: "This website is hosted by Vercel Inc." },
+            { label: "Address", value: "340 S Lemon Ave #4133, Walnut, CA 91789, United States" },
+            { label: "Website", value: "vercel.com", href: "https://vercel.com" },
+          ],
+        },
+        {
+          heading: "Intellectual property",
+          rows: [
+            {
+              value:
+                "Unless otherwise stated, all content on this site (text, structure, graphics and code) is the property of Valentin PASSE. Any reproduction, representation or distribution, in whole or in part, without prior authorisation is prohibited.",
+            },
+          ],
+        },
+        {
+          heading: "Personal data",
+          rows: [
+            {
+              value:
+                "This site has no data-collection form. The only data processed is what you voluntarily send by email, used solely to answer your request.",
+            },
+            {
+              value:
+                "In accordance with the GDPR, you have the right to access, rectify and erase your personal data. To exercise it, write to passe.valentin@gmail.com.",
+            },
+          ],
+        },
+        {
+          heading: "Cookies and analytics",
+          rows: [
+            {
+              value:
+                "Audience-measurement tools (Vercel Analytics and Google Analytics) may set cookies for statistical purposes. They are enabled only after your consent, collected via the dedicated banner, and you can change your choice at any time.",
+            },
+          ],
+        },
+        {
+          heading: "Liability",
+          rows: [
+            {
+              value:
+                "The information published on this site is provided for guidance only and may change. Valentin PASSE strives to keep it accurate but cannot be held liable for errors, for any unavailability of the site, or for the use made of it.",
+            },
+          ],
+        },
+      ],
     },
   },
 };

--- a/content/portfolioContent.ts
+++ b/content/portfolioContent.ts
@@ -554,7 +554,7 @@ export const portfolioContent: Record<PortfolioLocale, PortfolioContent> = {
           rows: [
             { label: "Éditeur", value: "Valentin PASSE" },
             { label: "Statut", value: "Entrepreneur individuel (micro-entreprise)" },
-            { label: "SIREN", value: "947 577 623" },
+            { label: "SIRET", value: "947 577 623 00012" },
             { label: "N° de TVA intracommunautaire", value: "FR53947577623" },
             { label: "Localisation", value: "Nice (06200), France" },
             {
@@ -972,7 +972,7 @@ export const portfolioContent: Record<PortfolioLocale, PortfolioContent> = {
           rows: [
             { label: "Publisher", value: "Valentin PASSE" },
             { label: "Status", value: "Sole trader (French micro-entreprise)" },
-            { label: "SIREN", value: "947 577 623" },
+            { label: "SIRET", value: "947 577 623 00012" },
             { label: "EU VAT number", value: "FR53947577623" },
             { label: "Location", value: "Nice (06200), France" },
             {
@@ -1041,3 +1041,7 @@ export function getPortfolioContent(locale: PortfolioLocale): PortfolioContent {
 }
 
 export const portfolioEmail = EMAIL;
+
+// Home route for a given locale — single source of truth for the "/" vs "/en"
+// root used by the header, footer and secondary pages.
+export const homePath = (locale: PortfolioLocale): string => (locale === "en" ? "/en" : "/");

--- a/pages/legal-notice.tsx
+++ b/pages/legal-notice.tsx
@@ -1,0 +1,6 @@
+import React from "react";
+import { LegalNoticePage } from "../components/legalNotice";
+
+export default function LegalNotice() {
+  return <LegalNoticePage locale="en" />;
+}

--- a/pages/mentions-legales.tsx
+++ b/pages/mentions-legales.tsx
@@ -1,0 +1,6 @@
+import React from "react";
+import { LegalNoticePage } from "../components/legalNotice";
+
+export default function MentionsLegales() {
+  return <LegalNoticePage locale="fr" />;
+}

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -17,4 +17,20 @@
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
   </url>
+  <url>
+    <loc>https://www.valentin-passe.com/mentions-legales</loc>
+    <xhtml:link rel="alternate" hreflang="fr" href="https://www.valentin-passe.com/mentions-legales"/>
+    <xhtml:link rel="alternate" hreflang="en" href="https://www.valentin-passe.com/legal-notice"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://www.valentin-passe.com/mentions-legales"/>
+    <changefreq>yearly</changefreq>
+    <priority>0.3</priority>
+  </url>
+  <url>
+    <loc>https://www.valentin-passe.com/legal-notice</loc>
+    <xhtml:link rel="alternate" hreflang="fr" href="https://www.valentin-passe.com/mentions-legales"/>
+    <xhtml:link rel="alternate" hreflang="en" href="https://www.valentin-passe.com/legal-notice"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://www.valentin-passe.com/mentions-legales"/>
+    <changefreq>yearly</changefreq>
+    <priority>0.3</priority>
+  </url>
 </urlset>


### PR DESCRIPTION
Implémente l'issue **#32** : ajout d'une page **Mentions légales** conforme à la LCEN (art. 6-III).

## Contenu
- Routes SSR réelles : **`/mentions-legales`** (FR) et **`/legal-notice`** (EN), via un composant partagé `components/legalNotice/`.
- Sections : identité de l'éditeur (Valentin PASSE), statut **micro-entreprise**, **SIREN 947 577 623**, **n° TVA FR53947577623**, localisation (Nice 06200), contact e-mail, directeur de la publication, hébergeur **Vercel Inc.**, + propriété intellectuelle, données personnelles (RGPD), cookies/mesure d'audience, responsabilité.
- Lien « Mentions légales / Legal notice » ajouté au **footer** (FR et EN).

## SEO / technique
- `Layout` : nouvelles props `localeAlternates` + `secondary` → **canonical et hreflang corrects par page** (fr ↔ en réciproques, x-default = FR).
- `HeaderCustom` : mode **secondary** (page hors one-page) → les liens de nav renvoient vers les sections de l'accueil (`/#about`…) et le switch de langue pointe vers l'autre version légale. Comportement par défaut inchangé.
- `public/sitemap.xml` : ajout des 2 URLs avec hreflang.

## Validation
- ✅ `jest` : 73/73
- ✅ `eslint` : clean
- ✅ `next build` : `/mentions-legales` et `/legal-notice` prérendues
- ✅ HTML rendu vérifié (titre, canonical, hreflang réciproque, contenu légal, lien footer) ; home non régressée.

## À noter
- Texte légal standard (PI / RGPD / cookies / responsabilité) **à relire** par l'éditeur.
- Le **SIREN** est affiché (déduit du n° de TVA) ; le **SIRET** complet (SIREN + 5 chiffres NIC) peut être ajouté si souhaité.

Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)