### PR TITLE
fix(seo): remove orphan microdata meta tags from head (#36)

### DIFF
--- a/components/layout/layout.tsx
+++ b/components/layout/layout.tsx
@@ -177,9 +177,6 @@ export function Layout({
                 <meta name="viewport" content="width=device-width, initial-scale=1" />
                 <meta name="robots" content="index,follow" />
                 <meta name="theme-color" content="#18181b" />
-                <meta itemProp="name" content={resolvedTitle} />
-                <meta itemProp="description" content={resolvedDescription} />
-                <meta itemProp="image" content={ogImageUrl} />
 
                 <meta property="og:title" content={resolvedTitle} />
                 <meta property="og:description" content={resolvedDescription} />


### PR DESCRIPTION
## Résumé

Suppression des trois balises `<meta itemProp=…>` présentes dans le `<Head>` de [`components/layout/layout.tsx`](../blob/fix/36-microdata-orphelines/components/layout/layout.tsx) **sans élément parent `itemscope`/`itemtype`**. En microdata, un `itemprop` n'a de sens que dans la portée d'un `itemscope` : isolées, ces balises étaient du markup mort, ignoré par les parseurs.

Les données concernées (name / description / image) sont déjà exposées proprement via le JSON-LD (`@graph` : `WebSite` + `ProfilePage` + `Person`) → suppression sans aucune perte de données structurées.

```diff
-                <meta itemProp="name" content={resolvedTitle} />
-                <meta itemProp="description" content={resolvedDescription} />
-                <meta itemProp="image" content={ogImageUrl} />
```

Closes #36

## Critères d'acceptation
- [x] Suppression des 3 balises `itemProp` orphelines (anciennement `layout.tsx:77-79`, déplacées en 180-182 depuis l'audit)
- [x] Plus aucune balise `itemProp` sans `itemscope` dans le `<head>` (vérifié par recherche globale : 0 occurrence restante de `itemProp`/`itemscope`/`itemtype` dans tout le projet)

## Qualité
- `npm run lint` ✅
- `npm run build` ✅
- `npm test` ✅ (73 tests, 6 suites)

## Notes
- Aucune refacto / anti-duplication requise (suppression nette de 3 lignes).
- Aucune variable n'est devenue inutilisée : `resolvedTitle`, `resolvedDescription` et `ogImageUrl` restent consommées par les balises OG/Twitter, le canonical et le JSON-LD.
- Le plan détaillé est tenu en local sous `docs/issues/36/plan.md` (le dossier `docs/` est volontairement gitignoré dans ce repo).