### PR TITLE
fix(seo): clean up sitemap — drop changefreq/priority, add lastmod (#37)

### DIFF
--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -3,34 +3,30 @@
         xmlns:xhtml="http://www.w3.org/1999/xhtml">
   <url>
     <loc>https://www.valentin-passe.com/</loc>
+    <lastmod>2026-06-18</lastmod>
     <xhtml:link rel="alternate" hreflang="fr" href="https://www.valentin-passe.com/"/>
     <xhtml:link rel="alternate" hreflang="en" href="https://www.valentin-passe.com/en"/>
     <xhtml:link rel="alternate" hreflang="x-default" href="https://www.valentin-passe.com/"/>
-    <changefreq>monthly</changefreq>
-    <priority>1.0</priority>
   </url>
   <url>
     <loc>https://www.valentin-passe.com/en</loc>
+    <lastmod>2026-06-18</lastmod>
     <xhtml:link rel="alternate" hreflang="fr" href="https://www.valentin-passe.com/"/>
     <xhtml:link rel="alternate" hreflang="en" href="https://www.valentin-passe.com/en"/>
     <xhtml:link rel="alternate" hreflang="x-default" href="https://www.valentin-passe.com/"/>
-    <changefreq>monthly</changefreq>
-    <priority>0.9</priority>
   </url>
   <url>
     <loc>https://www.valentin-passe.com/mentions-legales</loc>
+    <lastmod>2026-06-18</lastmod>
     <xhtml:link rel="alternate" hreflang="fr" href="https://www.valentin-passe.com/mentions-legales"/>
     <xhtml:link rel="alternate" hreflang="en" href="https://www.valentin-passe.com/legal-notice"/>
     <xhtml:link rel="alternate" hreflang="x-default" href="https://www.valentin-passe.com/mentions-legales"/>
-    <changefreq>yearly</changefreq>
-    <priority>0.3</priority>
   </url>
   <url>
     <loc>https://www.valentin-passe.com/legal-notice</loc>
+    <lastmod>2026-06-18</lastmod>
     <xhtml:link rel="alternate" hreflang="fr" href="https://www.valentin-passe.com/mentions-legales"/>
     <xhtml:link rel="alternate" hreflang="en" href="https://www.valentin-passe.com/legal-notice"/>
     <xhtml:link rel="alternate" hreflang="x-default" href="https://www.valentin-passe.com/mentions-legales"/>
-    <changefreq>yearly</changefreq>
-    <priority>0.3</priority>
   </url>
 </urlset>


### PR DESCRIPTION
## Résumé

Nettoyage de [`public/sitemap.xml`](../blob/fix/37-sitemap-cleanup/public/sitemap.xml) :
- **Suppression** de `<changefreq>` et `<priority>` sur les 4 URLs — deux signaux **ignorés par Google**.
- **Ajout** d'un `<lastmod>` (format W3C `YYYY-MM-DD`) sur chaque URL, placé juste après `<loc>` (séquence XSD sitemaps.org).

Les `<loc>` et les `<xhtml:link>` hreflang (FR/EN/x-default) sont **conservés intacts**.

### Valeur de `lastmod`
`2026-06-18` sur les 4 URLs = **date réelle** du dernier changement de contenu (le contenu home `content/portfolioContent.ts` et les pages légales ont été édités ce jour-là). Choix d'une date *réelle par page* plutôt qu'une date « deploy » factice identique rebumpée à chaque build (anti-pattern que Google finit par ignorer). Ici les dates convergent honnêtement car le contenu a réellement été touché le même jour.

Le fichier reste **statique** : pas de génération dynamique introduite (c'est le périmètre de #31). La date est donc à actualiser manuellement lors d'un vrai changement de contenu.

Closes #37

## Critères d'acceptation
- [x] Retirer `changefreq` et `priority` de toutes les URLs (vérifié : 0 occurrence)
- [x] Ajouter `lastmod` sur chaque URL (vérifié : 4 `<lastmod>` / 4 `<url>`, toutes au format W3C)
- [x] `sitemap.xml` valide (parsé sans erreur par un parseur XML)

## Qualité
- Validation XML : well-formed, 4 url / 4 loc / 4 lastmod / 0 changefreq / 0 priority ✅
- `npm run lint` ✅
- `npm run build` ✅
- `npm test` ✅ (73 tests, 6 suites)

## Notes
- Aucune refacto / duplication (asset statique concis).
- Le plan détaillé est en local sous `docs/issues/37/plan.md` (`docs/` est volontairement gitignoré dans ce repo).
- Connexe à #31 : la génération dynamique du sitemap (qui automatiserait `lastmod`) y est rattachée et reste hors périmètre ici.