### PR TITLE
perf(seo): preconnect vers prod.spline.design (#44)

### DIFF
--- a/components/layout/layout.tsx
+++ b/components/layout/layout.tsx
@@ -167,6 +167,22 @@ export function Layout({
         <div className={styles.mainContainer}>
             <Head>
                 <meta charSet="utf-8" />
+
+                {/*
+                  Warm up the cross-origin connection to prod.spline.design as early
+                  as possible in the head: the 3D hero (home pages only) loads the
+                  Spline WebGL runtime + a remote scene from there at first paint.
+                  crossOrigin is required so the preconnected socket is reused for the
+                  scene's CORS fetch; dns-prefetch is a legacy fallback. Skipped on
+                  secondary pages (legal), which never render the hero.
+                */}
+                {!secondary && (
+                    <>
+                        <link rel="preconnect" href="https://prod.spline.design" crossOrigin="anonymous" />
+                        <link rel="dns-prefetch" href="https://prod.spline.design" />
+                    </>
+                )}
+
                 <meta name="author" content="Valentin PASSE" />
                 <meta name="copyright" content="Portfolio of Valentin PASSE" />
                 <meta
@@ -201,21 +217,6 @@ export function Layout({
                 <link rel="alternate" hrefLang="fr" href={frUrl} />
                 <link rel="alternate" hrefLang="en" href={enUrl} />
                 <link rel="alternate" hrefLang="x-default" href={frUrl} />
-
-                {/*
-                  The 3D hero (home pages only) loads the Spline WebGL runtime and a
-                  remote scene from prod.spline.design at first paint. Warm up the
-                  cross-origin connection ahead of that CORS fetch. crossOrigin is
-                  required so the preconnected socket is reused for the CORS request;
-                  dns-prefetch is a legacy fallback. Skipped on secondary pages
-                  (legal), which never render the hero.
-                */}
-                {!secondary && (
-                    <>
-                        <link rel="preconnect" href="https://prod.spline.design" crossOrigin="anonymous" />
-                        <link rel="dns-prefetch" href="https://prod.spline.design" />
-                    </>
-                )}
 
                 <title>{resolvedTitle}</title>
                 <link rel="icon" href="/favicon.ico" />

--- a/components/layout/layout.tsx
+++ b/components/layout/layout.tsx
@@ -202,6 +202,21 @@ export function Layout({
                 <link rel="alternate" hrefLang="en" href={enUrl} />
                 <link rel="alternate" hrefLang="x-default" href={frUrl} />
 
+                {/*
+                  The 3D hero (home pages only) loads the Spline WebGL runtime and a
+                  remote scene from prod.spline.design at first paint. Warm up the
+                  cross-origin connection ahead of that CORS fetch. crossOrigin is
+                  required so the preconnected socket is reused for the CORS request;
+                  dns-prefetch is a legacy fallback. Skipped on secondary pages
+                  (legal), which never render the hero.
+                */}
+                {!secondary && (
+                    <>
+                        <link rel="preconnect" href="https://prod.spline.design" crossOrigin="anonymous" />
+                        <link rel="dns-prefetch" href="https://prod.spline.design" />
+                    </>
+                )}
+
                 <title>{resolvedTitle}</title>
                 <link rel="icon" href="/favicon.ico" />
 


### PR DESCRIPTION
## Contexte
Issue #44 [SEO][L5] (priorité basse, perf) : le hero 3D charge le runtime WebGL Spline + une scène distante depuis `prod.spline.design` au premier paint.

## Changements
- `components/layout/layout.tsx` : ajout dans le `<Head>` d'un `<link rel="preconnect" href="https://prod.spline.design" crossOrigin="anonymous">` (+ `dns-prefetch` en fallback legacy), **uniquement sur les pages home** (`!secondary`) — les pages légales ne rendent pas le hero. `crossOrigin` est requis pour que la socket préconnectée soit réutilisée par le fetch CORS de la scène WebGL.

## Qualité
`npm run lint` ✅ · `npm run build` ✅ · `npm test` ✅ (73 tests)

## Critères d'acceptation
- [x] `preconnect` vers `prod.spline.design` présent dans le `<head>`
- [ ] Pas de régression INP en données terrain — **différé** (GSC/CrUX non connecté, comme indiqué dans l'issue)

Closes #44