### PR TITLE
feat(seo): règles robots.txt explicites pour les crawlers IA (#43)

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,4 +1,29 @@
+# robots.txt — https://www.valentin-passe.com
+
+# Default policy: allow every crawler to access the whole site.
 User-agent: *
 Allow: /
+
+# AI search / answer-engine crawlers — explicitly allowed (citability is
+# desired for AI Overviews, ChatGPT, Perplexity, etc.).
+User-agent: GPTBot
+Allow: /
+
+User-agent: OAI-SearchBot
+Allow: /
+
+User-agent: ChatGPT-User
+Allow: /
+
+User-agent: ClaudeBot
+Allow: /
+
+User-agent: PerplexityBot
+Allow: /
+
+# AI training-dataset crawler — opted out (no inclusion in Common Crawl
+# training corpora). Search/citation bots above remain allowed.
+User-agent: CCBot
+Disallow: /
 
 Sitemap: https://www.valentin-passe.com/sitemap.xml


### PR DESCRIPTION
## Contexte
Issue #43 [SEO][L4] (priorité basse) : `robots.txt` n'avait qu'une règle générique `User-agent: *`. On rend l'intention de crawl explicite par agent IA.

## Décision
Conformément au choix retenu : **autoriser explicitement les bots de recherche/citation IA** et **opt-out des datasets d'entraînement** via CCBot.

## Changements (`public/robots.txt`)
- `Allow: /` explicite pour : `GPTBot`, `OAI-SearchBot`, `ChatGPT-User`, `ClaudeBot`, `PerplexityBot`.
- `Disallow: /` pour `CCBot` (Common Crawl → corpora d'entraînement) — les bots de citation ci-dessus restent autorisés.
- Conserve la règle générique `User-agent: * / Allow: /` et la directive `Sitemap:`.

> Rappel robots.txt : chaque crawler applique le groupe `User-agent` **le plus spécifique** qui le concerne et ignore `*` s'il a son propre groupe — donc CCBot lit son `Disallow`, les bots IA listés lisent leur `Allow`. La directive `Sitemap` reste globale.

## Lien
Connexe à #31 (qui édite aussi `robots.txt`) ; cette PR se limite aux sections crawlers IA. Pas de conflit en cours (#31 non démarrée).

## Qualité
`npm run lint` ✅ · `npm run build` ✅ · `npm test` ✅ (73 tests) — asset statique, aucun impact runtime.

## Critères d'acceptation
- [x] `robots.txt` contient des sections nommées par crawler IA cohérentes avec la décision d'opt-in/out (citation autorisée, entraînement CCBot exclu)

Closes #43