### PR TITLE
perf(hero): différer le montage du hero Spline hors de la fenêtre LCP (#56)

### DIFF
--- a/components/headerCustom/headerCustom.tsx
+++ b/components/headerCustom/headerCustom.tsx
@@ -129,7 +129,7 @@ export function HeaderCustom({ locale, secondary = false, localeSwitchHref }: He
           className={styles.brand}
           onClick={secondary ? undefined : (event) => handleAnchorNavigation(event, "#hero", "hero")}
         >
-          <Image src={Logo} width={44} height={52} alt="Logo Valentin PASSE" />
+          <Image src={Logo} width={44} height={52} alt="Logo Valentin PASSE" priority />
           <span className={styles.brandText}>
             <span className={styles.brandTitle}>Valentin Passe</span>
             <span className={styles.brandSubtitle}>Fullstack .NET</span>

--- a/components/heroSection/heroSection.tsx
+++ b/components/heroSection/heroSection.tsx
@@ -13,6 +13,27 @@ const Spline = dynamic(() => import("@splinetool/react-spline"), {
 
 const SPLINE_SCENE = "https://prod.spline.design/dJqTIQ-tE3ULUPMi/scene.splinecode";
 
+// Schedule the (heavy) Spline mount during browser idle time so its ~1.5-2 MB
+// WebGL runtime never evaluates inside the critical LCP / first-input window.
+// `requestIdleCallback` keeps it off the main thread until the page is quiet;
+// the `timeout` is a hard cap so the 3D still appears promptly on fast devices.
+// Falls back to a short `setTimeout` where the API is unavailable (e.g. Safari,
+// jsdom in tests).
+function scheduleIdle(callback: () => void, timeout: number): number {
+  if (typeof window !== "undefined" && typeof window.requestIdleCallback === "function") {
+    return window.requestIdleCallback(callback, { timeout });
+  }
+  return window.setTimeout(callback, 200);
+}
+
+function cancelIdle(handle: number): void {
+  if (typeof window !== "undefined" && typeof window.cancelIdleCallback === "function") {
+    window.cancelIdleCallback(handle);
+  } else {
+    window.clearTimeout(handle);
+  }
+}
+
 type HeroSectionProps = {
   locale?: PortfolioLocale;
 };
@@ -32,6 +53,11 @@ function HeroBackground() {
   const rafRef = useRef<number | null>(null);
   const lastUserMoveRef = useRef(0);
   const startLoopRef = useRef<() => void>(() => undefined);
+  // Tracks whether the scene has been mounted, and the pending idle handle, so
+  // the observer defers the first mount but resumes the loop instantly on later
+  // re-entries into the viewport.
+  const enabledRef = useRef(false);
+  const idleHandleRef = useRef<number | null>(null);
 
   useEffect(() => {
     if (prefersReducedMotion()) {
@@ -112,18 +138,37 @@ function HeroBackground() {
 
     startLoopRef.current = startLoop;
 
-    // Mount the scene and run the loop only while the hero is on screen; the
-    // loop is fully stopped once it scrolls out of view. Setting state from the
-    // observer callback is the recommended "subscribe to an external system"
-    // pattern (avoids a synchronous setState in the effect body).
+    // Defer the heavy first mount to idle time so the WebGL runtime stays out of
+    // the LCP / first-input window, then run the loop only while the hero is on
+    // screen. Setting state from the observer callback is the recommended
+    // "subscribe to an external system" pattern (avoids a synchronous setState
+    // in the effect body).
+    const enableNow = () => {
+      idleHandleRef.current = null;
+      enabledRef.current = true;
+      setEnable3d(true);
+      // The motion loop starts from Spline's onLoad once the canvas exists.
+    };
+
+    const scheduleEnable = () => {
+      if (enabledRef.current || idleHandleRef.current !== null) {
+        return;
+      }
+      idleHandleRef.current = scheduleIdle(enableNow, 3000);
+    };
+
     const node = bgRef.current;
     let observer: IntersectionObserver | undefined;
     if (node) {
       observer = new IntersectionObserver(
         ([entry]) => {
           if (entry.isIntersecting) {
-            setEnable3d(true);
-            startLoop();
+            if (enabledRef.current) {
+              // Already mounted: just resume the motion on re-entry.
+              startLoop();
+            } else {
+              scheduleEnable();
+            }
           } else {
             stopLoop();
           }
@@ -137,6 +182,10 @@ function HeroBackground() {
       window.removeEventListener("pointermove", handleRealMove);
       observer?.disconnect();
       stopLoop();
+      if (idleHandleRef.current !== null) {
+        cancelIdle(idleHandleRef.current);
+        idleHandleRef.current = null;
+      }
     };
   }, []);
 


### PR DESCRIPTION
Closes #56.

## Contexte
Audit SEO du 2026-06-22 (Epic #45) — **Performance (CWV) 68/100**, catégorie la plus faible. Le hero **Spline (WebGL ~1,5–2 Mo)** est à `scroll = 0` : l'`IntersectionObserver` se déclenchait **immédiatement** au chargement et montait la scène sur le **main thread pendant la fenêtre LCP + première interaction** (estimations lab : LCP mobile 3,0–4,5 s, INP 200–350 ms).

## Changements
**`components/heroSection/heroSection.tsx`**
- Montage de la scène via **`requestIdleCallback`** (cap `timeout: 3000 ms`, fallback `setTimeout` pour Safari/jsdom) au lieu d'un montage immédiat → le runtime WebGL reste hors de la fenêtre critique. Le poster CSS `.backdrop` (déjà multi-gradient) couvre le hero jusqu'au montage, donc le LCP reste ancré sur le `<h1>` SSR / le backdrop, pas sur le canvas.
- Le 3D n'est monté **qu'une seule fois** : sur les ré-entrées dans le viewport, on **reprend simplement la boucle de mouvement** (`enabledRef`) au lieu de re-planifier un montage.
- L'idle handle en attente est **annulé au cleanup** (`cancelIdleCallback` / `clearTimeout`).

**`components/headerCustom/headerCustom.tsx`**
- Logo d'en-tête (au-dessus de la ligne de flottaison) passé en **`priority`** (était `lazy` par défaut) → évite un paint tardif.

## Vérifications
- ✅ `tsc --noEmit` — 0 erreur
- ✅ `eslint` (composants modifiés) — 0 erreur
- ✅ `jest` — **81/81 tests** passants (la boucle 3D n'est pas affectée ; le stub inert d'`IntersectionObserver` ne déclenche pas le chemin idle en test)
- ✅ `next build` — OK (6 pages statiques)
- `prefers-reduced-motion` et le fallback du backdrop restent fonctionnels.

## Critères d'acceptation (#56)
- [x] Le runtime Spline ne s'évalue plus pendant la fenêtre LCP (montage idle).
- [x] La page paraît visuellement complète avant Spline (poster CSS `.backdrop`), sans saut de layout.
- [x] Logo d'en-tête en `priority`.

## Hors-périmètre de cette PR (suivi ailleurs)
- **`fetchpriority="high"` sur les preloads CSS / police Archivo** — next/font injecte ces `<link>` automatiquement en Pages Router ; l'ajout de `fetchpriority` n'est pas trivial sans bidouiller le HTML généré. Gain marginal → à ouvrir en issue dédiée si souhaité, plutôt que de bloquer ce correctif.
- **Confirmation field-data** (LCP mobile < 2,5 s / INP < 200 ms via CrUX/Search Console) — étape de **monitoring post-déploiement** (Phase 4 de l'`ACTION-PLAN`), non bloquante pour le merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)