### PR TITLE
chore: ignore les dossiers de sortie d'audit SEO (*-audit/)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,9 @@ yarn.lock
 docs/
 .claude/
 
+# SEO audit output (generated locally by /claude-seo:seo-audit — not versioned)
+*-audit/
+
 # debug
 npm-debug.log*
 yarn-debug.log*


### PR DESCRIPTION
## Pourquoi
L'audit `/claude-seo:seo-audit` génère un dossier `{domaine}-audit/` (rapport, findings, HTML brut) **localement**. Ce contenu n'a pas vocation à être versionné.

## Changement
Ajoute `*-audit/` au `.gitignore` (pattern générique qui couvre `valentin-passe.com-audit/` ainsi que tout futur audit).

```
# SEO audit output (generated locally by /claude-seo:seo-audit — not versioned)
*-audit/
```

## Vérification
```
$ git check-ignore -v valentin-passe.com-audit
.gitignore:28:*-audit/	valentin-passe.com-audit
```
Le dossier n'apparaît plus dans `git status`. Aucun fichier d'audit n'était suivi auparavant (rien à `git rm`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)