### PR TITLE
feat(seo): liens GitHub/LinkedIn visibles et crawlables dans le footer (#57)

### DIFF
--- a/components/footerCustom/footerCustom.module.scss
+++ b/components/footerCustom/footerCustom.module.scss
@@ -65,6 +65,25 @@
 	color: var(--color-on-dark);
 }
 
+.socialLinks {
+	margin: 0.9rem 0 0;
+	padding: 0;
+	list-style: none;
+	display: flex;
+	flex-wrap: wrap;
+	gap: 1rem;
+}
+
+.socialLink {
+	color: var(--color-on-dark-muted);
+	text-decoration: underline;
+	text-underline-offset: 2px;
+}
+
+.socialLink:hover {
+	color: var(--color-on-dark);
+}
+
 .rights {
 	margin: 1rem 0 0;
 	color: var(--color-on-dark-faint);

--- a/components/footerCustom/footerCustom.test.tsx
+++ b/components/footerCustom/footerCustom.test.tsx
@@ -1,0 +1,34 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { FooterCustom } from "./footerCustom";
+import { portfolioSocialLinks } from "../../content/portfolioContent";
+
+describe("FooterCustom", () => {
+  it("renders visible, crawlable social links matching the JSON-LD sameAs URLs", () => {
+    render(<FooterCustom locale="fr" />);
+
+    for (const social of portfolioSocialLinks) {
+      const link = screen.getByRole("link", { name: social.ariaLabel.fr });
+      expect(link).toHaveAttribute("href", social.url);
+      expect(link).toHaveAttribute("target", "_blank");
+      expect(link).toHaveAttribute("rel", "noopener noreferrer");
+    }
+  });
+
+  it("localizes the social link aria-labels for the English locale", () => {
+    render(<FooterCustom locale="en" />);
+
+    const github = screen.getByRole("link", {
+      name: "Valentin PASSE's GitHub profile (opens in a new tab)",
+    });
+    expect(github).toHaveAttribute("href", "https://github.com/val0m");
+
+    const linkedin = screen.getByRole("link", {
+      name: "Valentin PASSE's LinkedIn profile (opens in a new tab)",
+    });
+    expect(linkedin).toHaveAttribute(
+      "href",
+      "https://www.linkedin.com/in/valentin-passe/",
+    );
+  });
+});

--- a/components/footerCustom/footerCustom.tsx
+++ b/components/footerCustom/footerCustom.tsx
@@ -2,7 +2,13 @@ import React from "react";
 import Link from "next/link";
 import Image from "next/image";
 import LogoHeader from "../../public/images/header/logo.webp";
-import { PortfolioLocale, getPortfolioContent, portfolioEmail, homePath } from "../../content/portfolioContent";
+import {
+  PortfolioLocale,
+  getPortfolioContent,
+  portfolioEmail,
+  portfolioSocialLinks,
+  homePath,
+} from "../../content/portfolioContent";
 import styles from "./footerCustom.module.scss";
 
 type FooterCustomProps = {
@@ -42,6 +48,21 @@ export function FooterCustom({ locale }: FooterCustomProps) {
           <a href={`mailto:${portfolioEmail}`} className={styles.emailLink}>
             {portfolioEmail}
           </a>
+          <ul className={styles.socialLinks}>
+            {portfolioSocialLinks.map((link) => (
+              <li key={link.id}>
+                <a
+                  href={link.url}
+                  className={styles.socialLink}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  aria-label={link.ariaLabel[locale]}
+                >
+                  {link.label}
+                </a>
+              </li>
+            ))}
+          </ul>
           <p className={styles.rights}>{content.rights}</p>
           <Link href={content.legalLink.href} className={styles.legalLink}>
             {content.legalLink.label}

--- a/components/layout/layout.tsx
+++ b/components/layout/layout.tsx
@@ -2,7 +2,7 @@ import Head from "next/head";
 import React, { ReactNode } from "react";
 import { HeaderCustom } from "../headerCustom";
 import { FooterCustom } from "../footerCustom";
-import { PortfolioLocale, portfolioEmail } from "../../content/portfolioContent";
+import { PortfolioLocale, portfolioEmail, portfolioSocialLinks } from "../../content/portfolioContent";
 import styles from "./layout.module.scss";
 
 type LocaleAlternates = {
@@ -155,10 +155,7 @@ export function Layout({
                     occupationLocation: { "@type": "City", name: "Nice" },
                     skills: ".NET, C#, Blazor, .NET MAUI, Azure, Clean Architecture, DDD, CQRS",
                 },
-                sameAs: [
-                    "https://github.com/val0m",
-                    "https://www.linkedin.com/in/valentin-passe/",
-                ],
+                sameAs: portfolioSocialLinks.map((link) => link.url),
             },
         ],
     };

--- a/content/portfolioContent.ts
+++ b/content/portfolioContent.ts
@@ -1051,6 +1051,38 @@ export function getPortfolioContent(locale: PortfolioLocale): PortfolioContent {
 
 export const portfolioEmail = EMAIL;
 
+type SocialLink = {
+  id: "github" | "linkedin";
+  label: string;
+  url: string;
+  ariaLabel: Record<PortfolioLocale, string>;
+};
+
+// Single source of truth for the external profile links. The same URLs feed
+// both the JSON-LD `sameAs` (components/layout) and the visible, crawlable
+// footer links, so the structured-data declarations and the rendered anchors
+// can never drift apart.
+export const portfolioSocialLinks: SocialLink[] = [
+  {
+    id: "github",
+    label: "GitHub",
+    url: "https://github.com/val0m",
+    ariaLabel: {
+      fr: "Profil GitHub de Valentin PASSE (nouvel onglet)",
+      en: "Valentin PASSE's GitHub profile (opens in a new tab)",
+    },
+  },
+  {
+    id: "linkedin",
+    label: "LinkedIn",
+    url: "https://www.linkedin.com/in/valentin-passe/",
+    ariaLabel: {
+      fr: "Profil LinkedIn de Valentin PASSE (nouvel onglet)",
+      en: "Valentin PASSE's LinkedIn profile (opens in a new tab)",
+    },
+  },
+];
+
 // Home route for a given locale — single source of truth for the "/" vs "/en"
 // root used by the header, footer and secondary pages.
 export const homePath = (locale: PortfolioLocale): string => (locale === "en" ? "/en" : "/");


### PR DESCRIPTION
Closes #57.

## Contexte
Audit SEO du 2026-06-22 (Epic #45). GitHub (`github.com/val0m`) et LinkedIn (`linkedin.com/in/valentin-passe/`) n'étaient déclarés **que dans le `sameAs` du JSON-LD** ([layout.tsx](components/layout/layout.tsx)) — **aucun lien `<a>` visible** sur la page (seuls des `mailto:` en sortie). Un `sameAs` non corroboré par un lien HTML rendu est un signal d'autorité/entité plus faible (SEO + GEO) et empêche le visiteur d'accéder aux profils.

## Changements
**`content/portfolioContent.ts`** — nouvelle constante **`portfolioSocialLinks`** (source unique de vérité) : URLs locale-indépendantes + aria-labels localisés FR/EN.

**`components/layout/layout.tsx`** — le `sameAs` du JSON-LD est désormais dérivé de cette constante (`portfolioSocialLinks.map(l => l.url)`) au lieu d'URLs en dur → les déclarations structurées et les liens rendus **ne peuvent plus diverger**.

**`components/footerCustom/footerCustom.tsx` (+ SCSS)** — liens visibles GitHub + LinkedIn dans la colonne contact :
- `target="_blank"` + `rel="noopener noreferrer"`, **pas de `nofollow`** (profils d'autorité légitimes).
- `aria-label` localisé FR/EN ; style aligné sur `.legalLink` existant.
- Footer présent sur **toutes** les pages (home + légales) → corroboration maximale.

**`components/footerCustom/footerCustom.test.tsx`** — nouveau test : présence des 2 liens, `href` exact, `rel`/`target`, localisation des aria-labels.

## Vérifications
- ✅ `tsc --noEmit` — 0 erreur
- ✅ `eslint` — 0 erreur
- ✅ `jest` — **83/83 tests** (8 suites, +2 nouveaux)
- ✅ `next build` — OK
- ✅ **HTML prérendu vérifié** :
  ```
  <a href="https://github.com/val0m" ... target="_blank" rel="noopener noreferrer" aria-label="Profil GitHub de Valentin PASSE (nouvel onglet)">
  <a href="https://www.linkedin.com/in/valentin-passe/" ... target="_blank" rel="noopener noreferrer" aria-label="...">
  "sameAs":["https://github.com/val0m","https://www.linkedin.com/in/valentin-passe/"]
  ```
  → ancres visibles **et** `sameAs` avec **URLs strictement identiques**.

## Critères d'acceptation (#57)
- [x] Liens GitHub + LinkedIn visibles et crawlables dans le HTML rendu (footer).
- [x] URLs strictement identiques aux entrées `sameAs` (garanti par la constante partagée).
- [x] `rel="noopener noreferrer"` + `target="_blank"` ; aria-labels localisés FR/EN.
- [x] Aucun impact CLS / a11y (liens texte, focus visible hérité, contraste `--color-on-dark-muted`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)