### PR TITLE
chore(seo): bascule l'URL par défaut du site sur www.valentin-passe.fr

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,5 +8,5 @@ NEXT_PUBLIC_GA_ID=
 
 # URL canonique du site (sans slash final), source de vérité pour canonical / og /
 # hreflang / JSON-LD. Variable inlinée au build Next.js : doit être présente lors du
-# `next build`. À défaut, le code retombe sur https://www.valentin-passe.com.
-NEXT_PUBLIC_SITE_URL=https://www.valentin-passe.com
+# `next build`. À défaut, le code retombe sur https://www.valentin-passe.fr.
+NEXT_PUBLIC_SITE_URL=https://www.valentin-passe.fr

--- a/components/layout/layout.tsx
+++ b/components/layout/layout.tsx
@@ -30,7 +30,7 @@ type LayoutProps = {
 
 const DEFAULT_LOCALE_ALTERNATES: LocaleAlternates = { fr: "/", en: "/en" };
 
-const SITE_URL = (process.env.NEXT_PUBLIC_SITE_URL || "https://www.valentin-passe.com").replace(/\/+$/, "");
+const SITE_URL = (process.env.NEXT_PUBLIC_SITE_URL || "https://www.valentin-passe.fr").replace(/\/+$/, "");
 const OG_IMAGE_PATH = "/og-image.jpg";
 
 function escapeJsonLd(value: unknown): string {

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -26,7 +26,7 @@ Based in Nice (06200), Provence-Alpes-Côte d'Azur, France. Works remote, hybrid
 ## Contact
 
 - Email: passe.valentin@gmail.com
-- Website: https://www.valentin-passe.com
+- Website: https://www.valentin-passe.fr
 - GitHub: https://github.com/val0m
 - LinkedIn: https://www.linkedin.com/in/valentin-passe/
 
@@ -36,9 +36,9 @@ Valentin PASSE est ingénieur Fullstack .NET freelance basé à Nice (06200), av
 
 ## Links
 
-- [Website](https://www.valentin-passe.com): One-page portfolio (English and French)
-- [Legal notice (EN)](https://www.valentin-passe.com/legal-notice)
-- [Mentions légales (FR)](https://www.valentin-passe.com/mentions-legales)
+- [Website](https://www.valentin-passe.fr): One-page portfolio (English and French)
+- [Legal notice (EN)](https://www.valentin-passe.fr/legal-notice)
+- [Mentions légales (FR)](https://www.valentin-passe.fr/mentions-legales)
 - [GitHub](https://github.com/val0m): Open-source and project work
 - [LinkedIn](https://www.linkedin.com/in/valentin-passe/): Professional profile
 - [Contact](mailto:passe.valentin@gmail.com): Direct email

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,4 +1,4 @@
-# robots.txt — https://www.valentin-passe.com
+# robots.txt — https://www.valentin-passe.fr
 
 # Default policy: allow every crawler to access the whole site.
 User-agent: *
@@ -26,4 +26,4 @@ Allow: /
 User-agent: CCBot
 Disallow: /
 
-Sitemap: https://www.valentin-passe.com/sitemap.xml
+Sitemap: https://www.valentin-passe.fr/sitemap.xml

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -2,31 +2,31 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
         xmlns:xhtml="http://www.w3.org/1999/xhtml">
   <url>
-    <loc>https://www.valentin-passe.com/</loc>
+    <loc>https://www.valentin-passe.fr/</loc>
     <lastmod>2026-06-18</lastmod>
-    <xhtml:link rel="alternate" hreflang="fr" href="https://www.valentin-passe.com/"/>
-    <xhtml:link rel="alternate" hreflang="en" href="https://www.valentin-passe.com/en"/>
-    <xhtml:link rel="alternate" hreflang="x-default" href="https://www.valentin-passe.com/"/>
+    <xhtml:link rel="alternate" hreflang="fr" href="https://www.valentin-passe.fr/"/>
+    <xhtml:link rel="alternate" hreflang="en" href="https://www.valentin-passe.fr/en"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://www.valentin-passe.fr/"/>
   </url>
   <url>
-    <loc>https://www.valentin-passe.com/en</loc>
+    <loc>https://www.valentin-passe.fr/en</loc>
     <lastmod>2026-06-18</lastmod>
-    <xhtml:link rel="alternate" hreflang="fr" href="https://www.valentin-passe.com/"/>
-    <xhtml:link rel="alternate" hreflang="en" href="https://www.valentin-passe.com/en"/>
-    <xhtml:link rel="alternate" hreflang="x-default" href="https://www.valentin-passe.com/"/>
+    <xhtml:link rel="alternate" hreflang="fr" href="https://www.valentin-passe.fr/"/>
+    <xhtml:link rel="alternate" hreflang="en" href="https://www.valentin-passe.fr/en"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://www.valentin-passe.fr/"/>
   </url>
   <url>
-    <loc>https://www.valentin-passe.com/mentions-legales</loc>
+    <loc>https://www.valentin-passe.fr/mentions-legales</loc>
     <lastmod>2026-06-18</lastmod>
-    <xhtml:link rel="alternate" hreflang="fr" href="https://www.valentin-passe.com/mentions-legales"/>
-    <xhtml:link rel="alternate" hreflang="en" href="https://www.valentin-passe.com/legal-notice"/>
-    <xhtml:link rel="alternate" hreflang="x-default" href="https://www.valentin-passe.com/mentions-legales"/>
+    <xhtml:link rel="alternate" hreflang="fr" href="https://www.valentin-passe.fr/mentions-legales"/>
+    <xhtml:link rel="alternate" hreflang="en" href="https://www.valentin-passe.fr/legal-notice"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://www.valentin-passe.fr/mentions-legales"/>
   </url>
   <url>
-    <loc>https://www.valentin-passe.com/legal-notice</loc>
+    <loc>https://www.valentin-passe.fr/legal-notice</loc>
     <lastmod>2026-06-18</lastmod>
-    <xhtml:link rel="alternate" hreflang="fr" href="https://www.valentin-passe.com/mentions-legales"/>
-    <xhtml:link rel="alternate" hreflang="en" href="https://www.valentin-passe.com/legal-notice"/>
-    <xhtml:link rel="alternate" hreflang="x-default" href="https://www.valentin-passe.com/mentions-legales"/>
+    <xhtml:link rel="alternate" hreflang="fr" href="https://www.valentin-passe.fr/mentions-legales"/>
+    <xhtml:link rel="alternate" hreflang="en" href="https://www.valentin-passe.fr/legal-notice"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://www.valentin-passe.fr/mentions-legales"/>
   </url>
 </urlset>

--- a/scripts/build-og-image.mjs
+++ b/scripts/build-og-image.mjs
@@ -44,7 +44,7 @@ const textSvg = Buffer.from(
     <text x="560" y="270" font-family="Arial, Helvetica, sans-serif" font-size="68" font-weight="700" fill="#ffffff">Valentin PASSE</text>
     <text x="560" y="332" font-family="Arial, Helvetica, sans-serif" font-size="38" font-weight="500" fill="#93c5fd">Freelance Fullstack .NET</text>
     <text x="560" y="402" font-family="Arial, Helvetica, sans-serif" font-size="24" fill="#cbd5e1">Architecture .NET · Blazor · IA utile</text>
-    <text x="560" y="582" font-family="Arial, Helvetica, sans-serif" font-size="22" fill="#94a3b8">valentin-passe.com</text>
+    <text x="560" y="582" font-family="Arial, Helvetica, sans-serif" font-size="22" fill="#94a3b8">valentin-passe.fr</text>
   </svg>`,
 );
 


### PR DESCRIPTION
## Objectif

Changer l'URL par défaut du site de `www.valentin-passe.com` vers `www.valentin-passe.fr`.

## Changements

Remplacement du domaine par défaut dans tout le code source (0 occurrence restante de l'ancien domaine) :

| Fichier | Rôle |
|---|---|
| `components/layout/layout.tsx` | Fallback de `SITE_URL` (canonical, og, hreflang, JSON-LD) |
| `.env.example` | Valeur d'exemple + commentaire de `NEXT_PUBLIC_SITE_URL` |
| `public/sitemap.xml` | Toutes les `<loc>` et liens hreflang |
| `public/robots.txt` | En-tête + ligne `Sitemap:` |
| `public/llms.txt` | Website + liens (EN/FR) |
| `scripts/build-og-image.mjs` | Texte affiché sur l'image OG |

Non touchés volontairement : l'email `passe.valentin@gmail.com` et les noms de fichiers `valentin-passe.jpg/.webp`.

## À prévoir hors code (rappel)

- ⚠️ Mettre à jour la variable `NEXT_PUBLIC_SITE_URL` dans les variables d'environnement **Vercel** (source de vérité au build) puis redéployer — le fallback `.fr` du code ne s'applique que si la variable est absente.
- Rattacher le domaine `www.valentin-passe.fr` au projet Vercel.
- Prévoir une redirection 301 de `.com` vers `.fr` pour préserver le SEO.
- Optionnel : régénérer l'image OG (`npm run build:og`) pour afficher le nouveau domaine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)