### PR TITLE
fix(hero): évite le crash client quand WebGL est indisponible

### DIFF
--- a/components/heroSection/heroSection.tsx
+++ b/components/heroSection/heroSection.tsx
@@ -60,11 +60,15 @@ function supportsWebGL(): boolean {
   }
   try {
     const canvas = document.createElement("canvas");
-    return Boolean(
-      window.WebGLRenderingContext &&
-        (canvas.getContext("webgl") ||
-          canvas.getContext("experimental-webgl"))
-    );
+    const gl = (window.WebGLRenderingContext &&
+      (canvas.getContext("webgl") ||
+        canvas.getContext("experimental-webgl"))) as WebGLRenderingContext | null;
+    // Release the probe's context immediately: browsers cap the number of live
+    // WebGL contexts, and holding an idle one for the page's lifetime (on top of
+    // Spline's own) wastes a slot and nudges toward the very "too many contexts"
+    // failure this guard exists to prevent.
+    gl?.getExtension("WEBGL_lose_context")?.loseContext();
+    return Boolean(gl);
   } catch {
     return false;
   }

--- a/components/heroSection/heroSection.tsx
+++ b/components/heroSection/heroSection.tsx
@@ -46,6 +46,53 @@ function prefersReducedMotion() {
   );
 }
 
+// Spline instantiates a three.js WebGLRenderer whose constructor THROWS
+// ("Error creating WebGL context.") on browsers/GPUs where a WebGL context
+// cannot be created (hardware acceleration off, blocklisted GPU, WebGL disabled
+// by policy/extension, out of contexts…). That throw happens synchronously in
+// react-spline's effect — the library only catches the async scene load — so it
+// escapes to React's root error boundary and replaces the whole page with
+// "Application error: a client-side exception has occurred". We probe support
+// cheaply first and never mount the scene when it is unavailable.
+function supportsWebGL(): boolean {
+  if (typeof window === "undefined" || typeof document === "undefined") {
+    return false;
+  }
+  try {
+    const canvas = document.createElement("canvas");
+    return Boolean(
+      window.WebGLRenderingContext &&
+        (canvas.getContext("webgl") ||
+          canvas.getContext("experimental-webgl"))
+    );
+  } catch {
+    return false;
+  }
+}
+
+// Safety net for the case above: even when the probe passes, actual scene
+// creation can still fail (context lost, out of memory, too many live WebGL
+// contexts, driver crash). This boundary contains any such failure to the hero
+// so the page degrades to its static gradient backdrop instead of crashing.
+class SplineErrorBoundary extends React.Component<
+  { children: React.ReactNode },
+  { failed: boolean }
+> {
+  state = { failed: false };
+
+  static getDerivedStateFromError() {
+    return { failed: true };
+  }
+
+  componentDidCatch() {
+    // Swallowed on purpose: the hero simply falls back to its backdrop.
+  }
+
+  render() {
+    return this.state.failed ? null : this.props.children;
+  }
+}
+
 function HeroBackground() {
   const [enable3d, setEnable3d] = useState(false);
   const bgRef = useRef<HTMLDivElement>(null);
@@ -64,6 +111,13 @@ function HeroBackground() {
 
   useEffect(() => {
     if (prefersReducedMotion()) {
+      return;
+    }
+
+    // Never attempt the WebGL scene when the browser cannot provide a context:
+    // mounting Spline there throws and takes the whole page down (see
+    // supportsWebGL). The static backdrop stays as the graceful fallback.
+    if (!supportsWebGL()) {
       return;
     }
 
@@ -227,13 +281,15 @@ function HeroBackground() {
   return (
     <div ref={bgRef} className={styles.background} aria-hidden="true">
       {enable3d && (
-        <div ref={hostRef} className={styles.splineHost}>
-          <Spline
-            className={styles.spline}
-            scene={SPLINE_SCENE}
-            onLoad={() => startLoopRef.current()}
-          />
-        </div>
+        <SplineErrorBoundary>
+          <div ref={hostRef} className={styles.splineHost}>
+            <Spline
+              className={styles.spline}
+              scene={SPLINE_SCENE}
+              onLoad={() => startLoopRef.current()}
+            />
+          </div>
+        </SplineErrorBoundary>
       )}
       <div className={styles.backdrop} />
     </div>


### PR DESCRIPTION
## Problème

Erreur en production sur https://www.valentin-passe.fr/ :

> Application error: a client-side exception has occurred while loading www.valentin-passe.fr

## Cause racine (reproduite avec Playwright)

Le hero montait `<Spline>` (three.js/WebGL) **sans error boundary**. Le constructeur `Application` de react-spline instancie un `WebGLRenderer` qui lève une exception **synchrone** (`Error creating WebGL context.`) lorsque le navigateur ne peut pas créer de contexte WebGL. Le `.catch()` de la lib ne couvre que le chargement *async* de la scène, pas ce throw du constructeur : l'erreur remontait donc jusqu'à la boundary racine de Next et remplaçait **toute la page** par « Application error ».

Visiteurs impactés (l'accueil se charge normalement pour la majorité) : accélération matérielle désactivée, GPU blocklisté, WebGL coupé par extension/policy/vie privée, certains mobiles / faible mémoire, trop de contextes WebGL, vieux navigateurs.

## Correctif — défense en profondeur ([heroSection.tsx](components/heroSection/heroSection.tsx))

1. **`supportsWebGL()`** — sonde légère avant de monter Spline ; sans contexte WebGL disponible, la scène 3D n'est jamais montée.
2. **`SplineErrorBoundary`** — filet de sécurité autour de `<Spline>` : tout échec (contexte perdu, OOM, crash driver même quand la sonde passe) est contenu au hero, qui retombe sur son **backdrop statique** déjà rendu, au lieu de crasher la page.

## Validation (build prod + `next start` local, avant/après)

| Scénario | Avant | Après |
|---|---|---|
| WebGL activé (user normal) | page OK, Spline monté | page OK, `<canvas>` présent ✅ |
| WebGL indisponible | **« Application error » — crash** | **page OK**, pas de `<canvas>`, aucun `pageerror` ✅ |

- `tsc --noEmit` ✅ · `eslint` ✅ · tests jest du hero ✅ (2/2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)