### PR TITLE
fix(hero): sonde WebGL2 (contexte réellement requis par Spline)

### DIFF
--- a/components/heroSection/heroSection.tsx
+++ b/components/heroSection/heroSection.tsx
@@ -46,23 +46,27 @@ function prefersReducedMotion() {
   );
 }
 
-// Spline instantiates a three.js WebGLRenderer whose constructor THROWS
-// ("Error creating WebGL context.") on browsers/GPUs where a WebGL context
-// cannot be created (hardware acceleration off, blocklisted GPU, WebGL disabled
-// by policy/extension, out of contexts…). That throw happens synchronously in
-// react-spline's effect — the library only catches the async scene load — so it
-// escapes to React's root error boundary and replaces the whole page with
-// "Application error: a client-side exception has occurred". We probe support
-// cheaply first and never mount the scene when it is unavailable.
-function supportsWebGL(): boolean {
+// Spline instantiates a three.js WebGLRenderer that needs a WebGL2 context (the
+// scene relies on float depth textures). Its constructor THROWS ("Error creating
+// WebGL context.") wherever that context cannot be created: hardware
+// acceleration off, blocklisted GPU, WebGL disabled by policy/extension, out of
+// contexts, or WebGL2 specifically unavailable — e.g. Firefox falling back to
+// software rendering reports "AllowWebgl2:false restricts context creation". A
+// WebGL1-only browser is enough to pass a naive check yet still fails here. That
+// throw happens synchronously in react-spline's effect — the library only
+// catches the async scene load — so it escapes to React's root error boundary
+// and replaces the whole page with "Application error: a client-side exception
+// has occurred". We probe for the exact context Spline needs (WebGL2) and never
+// mount the scene when it is unavailable, so those browsers degrade cleanly to
+// the static backdrop instead of mounting a doomed renderer.
+function supportsWebGL2(): boolean {
   if (typeof window === "undefined" || typeof document === "undefined") {
     return false;
   }
   try {
     const canvas = document.createElement("canvas");
-    const gl = (window.WebGLRenderingContext &&
-      (canvas.getContext("webgl") ||
-        canvas.getContext("experimental-webgl"))) as WebGLRenderingContext | null;
+    const gl = (window.WebGL2RenderingContext &&
+      canvas.getContext("webgl2")) as WebGL2RenderingContext | null;
     // Release the probe's context immediately: browsers cap the number of live
     // WebGL contexts, and holding an idle one for the page's lifetime (on top of
     // Spline's own) wastes a slot and nudges toward the very "too many contexts"
@@ -118,10 +122,10 @@ function HeroBackground() {
       return;
     }
 
-    // Never attempt the WebGL scene when the browser cannot provide a context:
-    // mounting Spline there throws and takes the whole page down (see
-    // supportsWebGL). The static backdrop stays as the graceful fallback.
-    if (!supportsWebGL()) {
+    // Never attempt the WebGL scene when the browser cannot provide a WebGL2
+    // context: mounting Spline there throws and takes the whole page down (see
+    // supportsWebGL2). The static backdrop stays as the graceful fallback.
+    if (!supportsWebGL2()) {
       return;
     }
 


### PR DESCRIPTION
## Contexte

Suite au fix [#66](https://github.com/val0m/valentinpasse-NextJS/pull/66) (plus de crash « Application error » sans WebGL), un cas restait imparfait : sur un navigateur qui a **WebGL 1 mais pas WebGL 2**, la scène ne s'affichait pas mais three.js loggait quand même une salve d'erreurs avant de retomber sur le fond.

Diagnostic reproduit en pilotant Firefox sur la machine — console :
```
THREE.WebGLRenderer: A WebGL context could not be created. Reason:
  WebGL creation failed: AllowWebgl2:false restricts context creation on this system.
WebGLRenderer: Floating point depth texture requires WebGL2.
```

La scène Spline exige un contexte **WebGL 2** (float depth textures). La sonde `supportsWebGL()` testait **WebGL 1** : elle passait donc à tort sur un navigateur WebGL1-only (typiquement Firefox retombé en rendu logiciel), Spline se montait, three.js échouait, puis on retombait sur le backdrop — avec du bruit console au passage.

## Correctif

`supportsWebGL()` → `supportsWebGL2()` : on sonde `canvas.getContext("webgl2")` (le contexte réellement requis). Les navigateurs sans WebGL 2 ne tentent plus de monter la scène et dégradent proprement sur le fond statique. L'`SplineErrorBoundary` reste le filet de sécurité pour les échecs survenant après une sonde réussie.

## Validation (build prod + Playwright, localhost)

| Scénario | Crash | Canvas monté | Erreurs WebGL/three |
|---|---|---|---|
| WebGL 2 disponible (visiteur normal) | non | **oui** (animation) | aucune |
| WebGL 1 seul, WebGL 2 bloqué | non | **non** (repli net) | **aucune** |
| Aucun WebGL | non | non | aucune |

- `tsc --noEmit` ✅ · `eslint` ✅ · tests jest du hero ✅ (2/2)

Aucun changement visible pour l'utilisateur (il faut WebGL 2 pour l'animation de toute façon) — la dégradation est simplement plus propre.

🤖 Generated with [Claude Code](https://claude.com/claude-code)