### PR TITLE
feat(hero, projets): hero sans WebGL + section Projets en bento holographique (#68)

### DIFF
--- a/components/heroSection/heroSection.module.scss
+++ b/components/heroSection/heroSection.module.scss
@@ -10,9 +10,41 @@
 	}
 }
 
+/*
+  Two slow, offset drifts. Only `transform` is animated, so both blooms stay on
+  the compositor and never trigger layout or paint.
+*/
+@keyframes heroBloomDriftA {
+	0%,
+	100% {
+		transform: translate3d(-5%, -3%, 0) scale(1);
+	}
+
+	50% {
+		transform: translate3d(6%, 5%, 0) scale(1.18);
+	}
+}
+
+@keyframes heroBloomDriftB {
+	0%,
+	100% {
+		transform: translate3d(4%, 6%, 0) scale(1.12);
+	}
+
+	50% {
+		transform: translate3d(-6%, -4%, 0) scale(0.94);
+	}
+}
+
 .hero {
 	position: relative;
-	min-height: 100vh;
+	/* Fallback first for browsers without small-viewport units. */
+	min-height: clamp(560px, 82vh, 900px);
+	/*
+	  Deliberately under a full viewport, and in `svh` so mobile browser chrome
+	  cannot inflate it: the projects band must already peek above the fold.
+	*/
+	min-height: clamp(560px, 82svh, 900px);
 	display: flex;
 	align-items: center;
 	color: var(--color-on-dark);
@@ -20,46 +52,85 @@
 	background: linear-gradient(180deg, var(--color-dark) 0%, var(--color-dark-2) 100%);
 }
 
-/* ---- 3D background ------------------------------------------------------- */
-
-.background {
-	position: absolute;
-	inset: 0;
-	z-index: 0;
-	/* Let pointer events reach the Spline canvas so the 3D scene stays
-	   interactive; the overlay copy re-enables events only on its buttons. */
-	pointer-events: auto;
-}
-
-.splineHost {
-	position: absolute;
-	inset: 0;
-}
-
-.spline {
-	width: 100% !important;
-	height: 100% !important;
-}
+/* ---- CSS-only backdrop --------------------------------------------------- */
 
 .backdrop {
 	position: absolute;
 	inset: 0;
+	z-index: 0;
 	pointer-events: none;
-	background:
+}
+
+.blooms {
+	position: absolute;
+	inset: 0;
+	/* Isolates the two blooms' overflow from the section's own stacking. */
+	overflow: hidden;
+}
+
+.blooms::before,
+.blooms::after {
+	content: "";
+	position: absolute;
+	border-radius: 50%;
+	will-change: transform;
+}
+
+.blooms::before {
+	top: -22%;
+	left: -12%;
+	width: 68%;
+	height: 92%;
+	background: radial-gradient(
+		circle,
+		color-mix(in srgb, var(--color-accent) 34%, transparent) 0%,
+		transparent 68%
+	);
+	animation: heroBloomDriftA 28s ease-in-out infinite;
+}
+
+.blooms::after {
+	right: -18%;
+	bottom: -30%;
+	width: 62%;
+	height: 88%;
+	background: radial-gradient(
+		circle,
+		color-mix(in srgb, var(--color-accent-strong) 26%, transparent) 0%,
+		transparent 70%
+	);
+	animation: heroBloomDriftB 34s ease-in-out infinite;
+}
+
+/* Static hairline grid, faded toward the horizon. */
+.gridLines {
+	position: absolute;
+	inset: 0;
+	background-image:
 		linear-gradient(
 			to right,
-			color-mix(in srgb, var(--color-dark-2) 82%, transparent),
-			transparent 28%,
-			transparent 72%,
-			color-mix(in srgb, var(--color-dark-2) 82%, transparent)
+			color-mix(in srgb, var(--color-on-dark) 5%, transparent) 1px,
+			transparent 1px
 		),
 		linear-gradient(
 			to bottom,
-			color-mix(in srgb, var(--color-dark-2) 35%, transparent) 0%,
-			transparent 42%,
-			var(--color-dark-2) 100%
-		),
-		radial-gradient(circle at 18% 16%, color-mix(in srgb, var(--color-accent) 22%, transparent), transparent 34%);
+			color-mix(in srgb, var(--color-on-dark) 5%, transparent) 1px,
+			transparent 1px
+		);
+	background-size: 76px 76px;
+	-webkit-mask-image: radial-gradient(ellipse 90% 65% at 50% 108%, #000 0%, transparent 72%);
+	mask-image: radial-gradient(ellipse 90% 65% at 50% 108%, #000 0%, transparent 72%);
+}
+
+/*
+  Static SVG grain. Data URIs are covered by the existing `img-src 'self' data:`
+  directive, so this introduces no CSP allowance.
+*/
+.grain {
+	position: absolute;
+	inset: 0;
+	opacity: 0.05;
+	background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='140' height='140'%3E%3Cfilter id='g'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='3' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23g)'/%3E%3C/svg%3E");
 }
 
 /* ---- Overlay content ----------------------------------------------------- */
@@ -68,13 +139,12 @@
 	position: relative;
 	z-index: 1;
 	width: 100%;
-	/* Clicks fall through to the 3D scene; interactive children opt back in. */
-	pointer-events: none;
-	animation: fadeInUp 0.7s ease both;
-
-	@media (prefers-reduced-motion: reduce) {
-		animation: none;
-	}
+	/*
+	  No animation here on purpose: this block holds the <h1>, the LCP candidate.
+	  The previous `animation: fadeInUp .7s ease both` held it at opacity 0 until
+	  the animation started, delaying the largest paint. Only the secondary
+	  elements below fade in.
+	*/
 }
 
 .inner {
@@ -83,13 +153,13 @@
 	margin: 0 auto;
 	/* Fluid side padding so the hero breathes edge-to-edge on large/fullscreen
 	   displays instead of staying boxed in a narrow centred column. */
-	padding: 9rem clamp(1.5rem, 6vw, 7rem) 5rem;
+	padding: 8rem clamp(1.5rem, 6vw, 7rem) 4.5rem;
 	display: flex;
 	flex-direction: column;
 	gap: 2.6rem;
 
 	@media (max-width: 768px) {
-		padding: 8rem 6% 4rem;
+		padding: 7rem 6% 3.5rem;
 		gap: 2rem;
 	}
 }
@@ -108,9 +178,6 @@
 
 .headline {
 	max-width: 620px;
-	/* Re-enable selection/interaction on the copy over the pass-through overlay;
-	   the open areas around it still let the 3D scene receive pointer events. */
-	pointer-events: auto;
 }
 
 .eyebrow {
@@ -146,11 +213,15 @@
 	display: flex;
 	flex-wrap: wrap;
 	gap: 0.9rem;
-	/* Re-enable interaction over the pointer-events:none overlay. */
-	pointer-events: auto;
+	/* Secondary content: safe to fade in, unlike the headline above. */
+	animation: fadeInUp 0.6s ease both;
 
 	@media (max-width: 520px) {
 		width: 100%;
+	}
+
+	@media (prefers-reduced-motion: reduce) {
+		animation: none;
 	}
 }
 
@@ -208,7 +279,7 @@
 
 .btnOutline {
 	/* A denser translucent fill (no backdrop-filter) keeps the label readable
-	   over the moving 3D scene without the per-frame GPU re-blur cost. */
+	   over the backdrop without the per-frame GPU re-blur cost. */
 	background-color: color-mix(in srgb, var(--color-dark-2) 46%, transparent);
 	color: var(--color-on-dark);
 	border: 2px solid var(--color-on-dark-border);
@@ -226,10 +297,15 @@
 	grid-template-columns: repeat(3, minmax(0, 1fr));
 	gap: 0.9rem;
 	width: 100%;
-	pointer-events: auto;
+	/* Secondary content, fading in just behind the actions. */
+	animation: fadeInUp 0.6s ease 0.08s both;
 
 	@media (max-width: 768px) {
 		grid-template-columns: 1fr;
+	}
+
+	@media (prefers-reduced-motion: reduce) {
+		animation: none;
 	}
 }
 
@@ -238,8 +314,8 @@
 	border-radius: 20px;
 	border: 1px solid var(--color-on-dark-border);
 	/* Opaque-enough dark fill replaces backdrop-filter: blur(): the metrics stay
-	   legible over the animated Spline canvas without forcing a GPU re-blur of
-	   the moving backdrop on every frame (a major scroll-jank source in the hero). */
+	   legible over the backdrop without forcing a GPU re-blur on every frame
+	   (a major scroll-jank source in the previous hero). */
 	background: color-mix(in srgb, var(--color-dark-2) 82%, transparent);
 }
 
@@ -254,4 +330,11 @@
 	margin: 0.42rem 0 0;
 	color: var(--color-on-dark-muted);
 	line-height: 1.5;
+}
+
+@media (prefers-reduced-motion: reduce) {
+	.blooms::before,
+	.blooms::after {
+		animation: none;
+	}
 }

--- a/components/heroSection/heroSection.module.scss
+++ b/components/heroSection/heroSection.module.scss
@@ -1,11 +1,16 @@
-@keyframes fadeInUp {
+/*
+  Motion that never hides anything: the secondary blocks rise into place but stay
+  fully opaque. Fading them in from `opacity: 0` would leave the two CTAs
+  invisible — yet clickable — for the length of the animation, against a user
+  story that asks for both calls to action to be readable as the first screen
+  paints.
+*/
+@keyframes riseIn {
 	from {
-		opacity: 0;
-		transform: translateY(24px);
+		transform: translateY(18px);
 	}
 
 	to {
-		opacity: 1;
 		transform: translateY(0);
 	}
 }
@@ -38,11 +43,11 @@
 
 .hero {
 	position: relative;
-	/* Fallback first for browsers without small-viewport units. */
-	min-height: clamp(560px, 82vh, 900px);
 	/*
 	  Deliberately under a full viewport, and in `svh` so mobile browser chrome
 	  cannot inflate it: the projects band must already peek above the fold.
+	  No `vh` fallback: the build's CSS target supports small-viewport units, so
+	  Lightning CSS strips any such duplicate from the shipped stylesheet anyway.
 	*/
 	min-height: clamp(560px, 82svh, 900px);
 	display: flex;
@@ -73,7 +78,6 @@
 	content: "";
 	position: absolute;
 	border-radius: 50%;
-	will-change: transform;
 }
 
 .blooms::before {
@@ -213,8 +217,8 @@
 	display: flex;
 	flex-wrap: wrap;
 	gap: 0.9rem;
-	/* Secondary content: safe to fade in, unlike the headline above. */
-	animation: fadeInUp 0.6s ease both;
+	/* Secondary content: safe to animate, unlike the headline above. */
+	animation: riseIn 0.6s ease both;
 
 	@media (max-width: 520px) {
 		width: 100%;
@@ -297,8 +301,8 @@
 	grid-template-columns: repeat(3, minmax(0, 1fr));
 	gap: 0.9rem;
 	width: 100%;
-	/* Secondary content, fading in just behind the actions. */
-	animation: fadeInUp 0.6s ease 0.08s both;
+	/* Secondary content, rising just behind the actions. */
+	animation: riseIn 0.6s ease 0.08s both;
 
 	@media (max-width: 768px) {
 		grid-template-columns: 1fr;

--- a/components/heroSection/heroSection.test.tsx
+++ b/components/heroSection/heroSection.test.tsx
@@ -1,8 +1,33 @@
+import fs from "fs";
+import path from "path";
 import React from "react";
 import { render, screen } from "@testing-library/react";
 import { HeroSection } from "./heroSection";
+import { getPortfolioContent } from "../../content/portfolioContent";
+
+const heroStyles = fs.readFileSync(path.join(__dirname, "heroSection.module.scss"), "utf8");
+
+function mockMatchMedia(matcher: (query: string) => boolean) {
+  // jest.setup.ts installs matchMedia as writable but not configurable, so it is
+  // reassigned rather than redefined.
+  window.matchMedia = ((query: string) => ({
+    matches: matcher(query),
+    media: query,
+    onchange: null,
+    addListener: () => undefined,
+    removeListener: () => undefined,
+    addEventListener: () => undefined,
+    removeEventListener: () => undefined,
+    dispatchEvent: () => false,
+  })) as unknown as typeof window.matchMedia;
+}
 
 describe("HeroSection", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+    mockMatchMedia(() => false);
+  });
+
   it("renders English headline, actions and metrics when locale is 'en'", () => {
     render(<HeroSection locale="en" />);
 
@@ -23,5 +48,61 @@ describe("HeroSection", () => {
     expect(screen.getByLabelText("Actions principales")).toBeInTheDocument();
     expect(screen.getByRole("link", { name: "Voir les projets" })).toBeInTheDocument();
     expect(screen.getByText("ans de développement logiciel")).toBeInTheDocument();
+  });
+
+  it("resolves both localized CTA targets to existing sections", () => {
+    (["fr", "en"] as const).forEach((locale) => {
+      const { unmount } = render(<HeroSection locale={locale} />);
+      const hero = getPortfolioContent(locale).hero;
+
+      expect(screen.getByRole("link", { name: hero.primaryAction.label })).toHaveAttribute(
+        "href",
+        "#contact"
+      );
+      expect(screen.getByRole("link", { name: hero.secondaryAction.label })).toHaveAttribute(
+        "href",
+        "#projects"
+      );
+      unmount();
+    });
+  });
+
+  it("mounts no canvas and no WebGL surface", () => {
+    const { container } = render(<HeroSection locale="fr" />);
+
+    expect(container.querySelector("canvas")).toBeNull();
+    expect(container.querySelector("[class*='spline']")).toBeNull();
+  });
+
+  it("binds no scroll listener under prefers-reduced-motion", () => {
+    mockMatchMedia((query) => query === "(prefers-reduced-motion: reduce)");
+    const addEventListener = jest.spyOn(window, "addEventListener");
+
+    render(<HeroSection locale="fr" />);
+
+    expect(addEventListener.mock.calls.filter(([type]) => type === "scroll")).toHaveLength(0);
+  });
+
+  describe("stylesheet regressions", () => {
+    it("never animates the block holding the h1, the LCP candidate", () => {
+      // `animation: … both` used to hold .content — and therefore the <h1> — at
+      // opacity 0 until the animation started, delaying the largest paint.
+      const contentRule = heroStyles.match(/^\.content \{([\s\S]*?)^\}/m)?.[1];
+
+      expect(contentRule).toBeDefined();
+      // Comments may legitimately mention the removed animation.
+      expect(contentRule?.replace(/\/\*[\s\S]*?\*\//g, "")).not.toMatch(/animation/);
+    });
+
+    it("sizes the hero below a full viewport so the projects band peeks above the fold", () => {
+      expect(heroStyles).not.toMatch(/min-height:\s*100vh/);
+      expect(heroStyles).toMatch(/min-height:\s*clamp\(560px,\s*82svh,\s*900px\)/);
+    });
+
+    it("suppresses the backdrop drift under prefers-reduced-motion", () => {
+      expect(heroStyles).toMatch(
+        /@media \(prefers-reduced-motion: reduce\) \{[\s\S]*\.blooms::before,\s*\n\s*\.blooms::after \{\s*\n\s*animation: none;/
+      );
+    });
   });
 });

--- a/components/heroSection/heroSection.test.tsx
+++ b/components/heroSection/heroSection.test.tsx
@@ -4,28 +4,23 @@ import React from "react";
 import { render, screen } from "@testing-library/react";
 import { HeroSection } from "./heroSection";
 import { getPortfolioContent } from "../../content/portfolioContent";
+import {
+  NO_PREFERENCE,
+  REDUCED_MOTION,
+  mockMatchMedia,
+} from "../../lib/testing/mockMatchMedia";
 
 const heroStyles = fs.readFileSync(path.join(__dirname, "heroSection.module.scss"), "utf8");
 
-function mockMatchMedia(matcher: (query: string) => boolean) {
-  // jest.setup.ts installs matchMedia as writable but not configurable, so it is
-  // reassigned rather than redefined.
-  window.matchMedia = ((query: string) => ({
-    matches: matcher(query),
-    media: query,
-    onchange: null,
-    addListener: () => undefined,
-    removeListener: () => undefined,
-    addEventListener: () => undefined,
-    removeEventListener: () => undefined,
-    dispatchEvent: () => false,
-  })) as unknown as typeof window.matchMedia;
-}
+/** Body of the file's single top-level reduced-motion block. */
+const reducedMotionBlock = heroStyles.match(
+  /^@media \(prefers-reduced-motion: reduce\) \{([\s\S]*?)^\}/m
+)?.[1];
 
 describe("HeroSection", () => {
   afterEach(() => {
     jest.restoreAllMocks();
-    mockMatchMedia(() => false);
+    mockMatchMedia(NO_PREFERENCE);
   });
 
   it("renders English headline, actions and metrics when locale is 'en'", () => {
@@ -75,7 +70,7 @@ describe("HeroSection", () => {
   });
 
   it("binds no scroll listener under prefers-reduced-motion", () => {
-    mockMatchMedia((query) => query === "(prefers-reduced-motion: reduce)");
+    mockMatchMedia(REDUCED_MOTION);
     const addEventListener = jest.spyOn(window, "addEventListener");
 
     render(<HeroSection locale="fr" />);
@@ -99,10 +94,25 @@ describe("HeroSection", () => {
       expect(heroStyles).toMatch(/min-height:\s*clamp\(560px,\s*82svh,\s*900px\)/);
     });
 
-    it("suppresses the backdrop drift under prefers-reduced-motion", () => {
-      expect(heroStyles).toMatch(
-        /@media \(prefers-reduced-motion: reduce\) \{[\s\S]*\.blooms::before,\s*\n\s*\.blooms::after \{\s*\n\s*animation: none;/
+    it("suppresses the backdrop drift inside the reduced-motion block itself", () => {
+      // Asserted against the extracted block, not the whole file: the file holds
+      // several nested reduced-motion blocks, and a loose match would stay green
+      // even if this rule drifted out of its media query.
+      expect(reducedMotionBlock).toBeDefined();
+      expect(reducedMotionBlock).toMatch(
+        /\.blooms::before,\s*\.blooms::after \{\s*animation: none;\s*\}/
       );
+    });
+
+    it("never fades secondary blocks in from zero opacity", () => {
+      // An `opacity: 0` fill would leave the two CTAs invisible yet clickable
+      // while the animation runs.
+      const keyframes = heroStyles.match(/^@keyframes riseIn \{([\s\S]*?)^\}/m)?.[1];
+
+      expect(keyframes).toBeDefined();
+      expect(keyframes).not.toMatch(/opacity/);
+      // The removed keyframes are still named in a comment explaining the fix.
+      expect(heroStyles.replace(/\/\*[\s\S]*?\*\//g, "")).not.toMatch(/fadeInUp/);
     });
   });
 });

--- a/components/heroSection/heroSection.tsx
+++ b/components/heroSection/heroSection.tsx
@@ -95,8 +95,10 @@ export function HeroSection({ locale = "fr" }: HeroSectionProps) {
     // Coalesce scroll events to a single pending frame so fast scrolling never
     // queues redundant layout work.
     let ticking = false;
+    let frame: number | null = null;
     const update = () => {
       ticking = false;
+      frame = null;
       const el = contentRef.current;
       if (!el) {
         return;
@@ -110,7 +112,7 @@ export function HeroSection({ locale = "fr" }: HeroSectionProps) {
     const handleScroll = () => {
       if (!ticking) {
         ticking = true;
-        requestAnimationFrame(update);
+        frame = requestAnimationFrame(update);
       }
     };
 
@@ -118,7 +120,12 @@ export function HeroSection({ locale = "fr" }: HeroSectionProps) {
     // (e.g. when navigating to a hash).
     update();
     window.addEventListener("scroll", handleScroll, { passive: true });
-    return () => window.removeEventListener("scroll", handleScroll);
+    return () => {
+      window.removeEventListener("scroll", handleScroll);
+      if (frame !== null) {
+        cancelAnimationFrame(frame);
+      }
+    };
   }, []);
 
   return (

--- a/components/heroSection/heroSection.tsx
+++ b/components/heroSection/heroSection.tsx
@@ -1,305 +1,32 @@
-import React, { useEffect, useRef, useState } from "react";
-import dynamic from "next/dynamic";
+import React, { useEffect, useRef } from "react";
 import { PortfolioLocale, getPortfolioContent } from "../../content/portfolioContent";
+import { prefersReducedMotion } from "../../lib/mediaPreferences";
 import styles from "./heroSection.module.scss";
-
-// Spline ships a heavy WebGL runtime + loads a remote scene, so we defer it:
-// no SSR, lazy-loaded on the client, and only when the user has not requested
-// reduced motion. The dark gradient backdrop renders immediately as a fallback.
-const Spline = dynamic(() => import("@splinetool/react-spline"), {
-  ssr: false,
-  loading: () => null,
-});
-
-const SPLINE_SCENE = "https://prod.spline.design/dJqTIQ-tE3ULUPMi/scene.splinecode";
-
-// Schedule the (heavy) Spline mount during browser idle time so its ~1.5-2 MB
-// WebGL runtime never evaluates inside the critical LCP / first-input window.
-// `requestIdleCallback` keeps it off the main thread until the page is quiet;
-// the `timeout` is a hard cap so the 3D still appears promptly on fast devices.
-// Falls back to a short `setTimeout` where the API is unavailable (e.g. Safari,
-// jsdom in tests).
-function scheduleIdle(callback: () => void, timeout: number): number {
-  if (typeof window !== "undefined" && typeof window.requestIdleCallback === "function") {
-    return window.requestIdleCallback(callback, { timeout });
-  }
-  return window.setTimeout(callback, 200);
-}
-
-function cancelIdle(handle: number): void {
-  if (typeof window !== "undefined" && typeof window.cancelIdleCallback === "function") {
-    window.cancelIdleCallback(handle);
-  } else {
-    window.clearTimeout(handle);
-  }
-}
 
 type HeroSectionProps = {
   locale?: PortfolioLocale;
 };
 
-function prefersReducedMotion() {
+/**
+ * Decorative backdrop, CSS only — it replaces the Spline WebGL scene this hero
+ * used to mount (~2 MB of runtime, a cross-origin scene fetch, a WebGL2
+ * capability probe, an error boundary and a synthetic-pointer rAF loop).
+ *
+ * Three stacked layers over the section's own dark gradient:
+ *   1. two slow radial blooms, animated on `transform` only, so the drift stays
+ *      on the compositor and never repaints;
+ *   2. a static hairline grid fading toward the horizon, for the technical
+ *      register;
+ *   3. a static SVG grain that breaks gradient banding on wide dark surfaces.
+ *
+ * Nothing here is interactive, nothing is fetched, and nothing can throw.
+ */
+function HeroBackdrop() {
   return (
-    typeof window !== "undefined" &&
-    typeof window.matchMedia === "function" &&
-    window.matchMedia("(prefers-reduced-motion: reduce)").matches
-  );
-}
-
-// Spline instantiates a three.js WebGLRenderer that needs a WebGL2 context (the
-// scene relies on float depth textures). Its constructor THROWS ("Error creating
-// WebGL context.") wherever that context cannot be created: hardware
-// acceleration off, blocklisted GPU, WebGL disabled by policy/extension, out of
-// contexts, or WebGL2 specifically unavailable — e.g. Firefox falling back to
-// software rendering reports "AllowWebgl2:false restricts context creation". A
-// WebGL1-only browser is enough to pass a naive check yet still fails here. That
-// throw happens synchronously in react-spline's effect — the library only
-// catches the async scene load — so it escapes to React's root error boundary
-// and replaces the whole page with "Application error: a client-side exception
-// has occurred". We probe for the exact context Spline needs (WebGL2) and never
-// mount the scene when it is unavailable, so those browsers degrade cleanly to
-// the static backdrop instead of mounting a doomed renderer.
-function supportsWebGL2(): boolean {
-  if (typeof window === "undefined" || typeof document === "undefined") {
-    return false;
-  }
-  try {
-    const canvas = document.createElement("canvas");
-    const gl = (window.WebGL2RenderingContext &&
-      canvas.getContext("webgl2")) as WebGL2RenderingContext | null;
-    // Release the probe's context immediately: browsers cap the number of live
-    // WebGL contexts, and holding an idle one for the page's lifetime (on top of
-    // Spline's own) wastes a slot and nudges toward the very "too many contexts"
-    // failure this guard exists to prevent.
-    gl?.getExtension("WEBGL_lose_context")?.loseContext();
-    return Boolean(gl);
-  } catch {
-    return false;
-  }
-}
-
-// Safety net for the case above: even when the probe passes, actual scene
-// creation can still fail (context lost, out of memory, too many live WebGL
-// contexts, driver crash). This boundary contains any such failure to the hero
-// so the page degrades to its static gradient backdrop instead of crashing.
-class SplineErrorBoundary extends React.Component<
-  { children: React.ReactNode },
-  { failed: boolean }
-> {
-  state = { failed: false };
-
-  static getDerivedStateFromError() {
-    return { failed: true };
-  }
-
-  componentDidCatch() {
-    // Swallowed on purpose: the hero simply falls back to its backdrop.
-  }
-
-  render() {
-    return this.state.failed ? null : this.props.children;
-  }
-}
-
-function HeroBackground() {
-  const [enable3d, setEnable3d] = useState(false);
-  const bgRef = useRef<HTMLDivElement>(null);
-  const hostRef = useRef<HTMLDivElement>(null);
-  const rafRef = useRef<number | null>(null);
-  const lastUserMoveRef = useRef(0);
-  const startLoopRef = useRef<() => void>(() => undefined);
-  // Tracks whether the scene has been mounted, and the pending idle handle, so
-  // the observer defers the first mount but resumes the loop instantly on later
-  // re-entries into the viewport.
-  const enabledRef = useRef(false);
-  const idleHandleRef = useRef<number | null>(null);
-  // Tracks whether the hero is currently on screen, so a tab-visibility change
-  // only resumes the ambient motion when the scene is actually visible.
-  const isIntersectingRef = useRef(false);
-
-  useEffect(() => {
-    if (prefersReducedMotion()) {
-      return;
-    }
-
-    // Never attempt the WebGL scene when the browser cannot provide a WebGL2
-    // context: mounting Spline there throws and takes the whole page down (see
-    // supportsWebGL2). The static backdrop stays as the graceful fallback.
-    if (!supportsWebGL2()) {
-      return;
-    }
-
-    // Record genuine cursor activity so the auto-motion can yield to it.
-    // Our synthetic events have isTrusted === false and are ignored here.
-    const handleRealMove = (event: PointerEvent | MouseEvent) => {
-      if (event.isTrusted) {
-        lastUserMoveRef.current = performance.now();
-      }
-    };
-    window.addEventListener("pointermove", handleRealMove, { passive: true });
-
-    // Treat active scrolling as user activity too: while the page scrolls we
-    // stop feeding synthetic moves to the canvas so the (expensive) WebGL
-    // re-render never competes with the scroll's own compositing. The ambient
-    // motion resumes once scrolling settles (same idle delay as hover).
-    const handleScrollActivity = () => {
-      lastUserMoveRef.current = performance.now();
-    };
-    window.addEventListener("scroll", handleScrollActivity, { passive: true });
-
-    // Pause the auto-motion while the real cursor is moving (or the page is
-    // scrolling); it resumes after this short idle delay so genuine hover wins.
-    const idleDelayMs = 600;
-    // Cap the synthetic-move cadence: this is a slow decorative drift, so ~30
-    // dispatches/sec look identical to 60 while halving the Spline re-renders.
-    const frameIntervalMs = 1000 / 30;
-    let lastDispatch = 0;
-    let startTime: number | null = null;
-
-    const stopLoop = () => {
-      if (rafRef.current !== null) {
-        cancelAnimationFrame(rafRef.current);
-        rafRef.current = null;
-      }
-    };
-
-    // Drive the cursor-reactive Spline scene on its own: feed the canvas
-    // synthetic pointer moves along a slow Lissajous path so the 3D keeps
-    // animating without real mouse movement. The early return guards against
-    // stacking duplicate loops if this is re-triggered.
-    const startLoop = () => {
-      if (rafRef.current !== null) {
-        return;
-      }
-      const canvas = hostRef.current?.querySelector("canvas");
-      if (!canvas) {
-        return;
-      }
-
-      const tick = (now: number) => {
-        if (startTime === null) {
-          startTime = now;
-        }
-
-        if (
-          now - lastUserMoveRef.current > idleDelayMs &&
-          now - lastDispatch >= frameIntervalMs
-        ) {
-          lastDispatch = now;
-          const t = (now - startTime) / 1000;
-          const rect = canvas.getBoundingClientRect();
-          const x = rect.left + rect.width * (0.5 + 0.32 * Math.sin(t * 0.55));
-          const y = rect.top + rect.height * (0.5 + 0.26 * Math.cos(t * 0.4));
-
-          canvas.dispatchEvent(
-            new PointerEvent("pointermove", {
-              clientX: x,
-              clientY: y,
-              pointerId: 1,
-              pointerType: "mouse",
-              isPrimary: true,
-              bubbles: true,
-              cancelable: true,
-            })
-          );
-          canvas.dispatchEvent(
-            new MouseEvent("mousemove", {
-              clientX: x,
-              clientY: y,
-              bubbles: true,
-              cancelable: true,
-            })
-          );
-        }
-
-        rafRef.current = requestAnimationFrame(tick);
-      };
-
-      rafRef.current = requestAnimationFrame(tick);
-    };
-
-    startLoopRef.current = startLoop;
-
-    // Defer the heavy first mount to idle time so the WebGL runtime stays out of
-    // the LCP / first-input window, then run the loop only while the hero is on
-    // screen. Setting state from the observer callback is the recommended
-    // "subscribe to an external system" pattern (avoids a synchronous setState
-    // in the effect body).
-    const enableNow = () => {
-      idleHandleRef.current = null;
-      enabledRef.current = true;
-      setEnable3d(true);
-      // The motion loop starts from Spline's onLoad once the canvas exists.
-    };
-
-    const scheduleEnable = () => {
-      if (enabledRef.current || idleHandleRef.current !== null) {
-        return;
-      }
-      idleHandleRef.current = scheduleIdle(enableNow, 3000);
-    };
-
-    const node = bgRef.current;
-    let observer: IntersectionObserver | undefined;
-    if (node) {
-      observer = new IntersectionObserver(
-        ([entry]) => {
-          isIntersectingRef.current = entry.isIntersecting;
-          if (entry.isIntersecting) {
-            if (enabledRef.current) {
-              // Already mounted: just resume the motion on re-entry.
-              startLoop();
-            } else {
-              scheduleEnable();
-            }
-          } else {
-            stopLoop();
-          }
-        },
-        { threshold: 0 }
-      );
-      observer.observe(node);
-    }
-
-    // Suspend the WebGL render loop entirely while the tab is hidden — there is
-    // no point animating an off-screen scene — and resume it only if the hero
-    // is still on screen when the tab comes back.
-    const handleVisibility = () => {
-      if (document.hidden) {
-        stopLoop();
-      } else if (enabledRef.current && isIntersectingRef.current) {
-        startLoop();
-      }
-    };
-    document.addEventListener("visibilitychange", handleVisibility);
-
-    return () => {
-      window.removeEventListener("pointermove", handleRealMove);
-      window.removeEventListener("scroll", handleScrollActivity);
-      document.removeEventListener("visibilitychange", handleVisibility);
-      observer?.disconnect();
-      stopLoop();
-      if (idleHandleRef.current !== null) {
-        cancelIdle(idleHandleRef.current);
-        idleHandleRef.current = null;
-      }
-    };
-  }, []);
-
-  return (
-    <div ref={bgRef} className={styles.background} aria-hidden="true">
-      {enable3d && (
-        <SplineErrorBoundary>
-          <div ref={hostRef} className={styles.splineHost}>
-            <Spline
-              className={styles.spline}
-              scene={SPLINE_SCENE}
-              onLoad={() => startLoopRef.current()}
-            />
-          </div>
-        </SplineErrorBoundary>
-      )}
-      <div className={styles.backdrop} />
+    <div className={styles.backdrop} aria-hidden="true">
+      <div className={styles.blooms} />
+      <div className={styles.gridLines} />
+      <div className={styles.grain} />
     </div>
   );
 }
@@ -358,8 +85,8 @@ export function HeroSection({ locale = "fr" }: HeroSectionProps) {
   const hero = getPortfolioContent(locale).hero;
   const contentRef = useRef<HTMLDivElement>(null);
 
-  // Parallax fade of the hero copy as the user scrolls past it, mirroring the
-  // source component. Skipped entirely under prefers-reduced-motion.
+  // Parallax fade of the hero copy as the user scrolls past it. Skipped entirely
+  // under prefers-reduced-motion.
   useEffect(() => {
     if (prefersReducedMotion()) {
       return;
@@ -396,7 +123,7 @@ export function HeroSection({ locale = "fr" }: HeroSectionProps) {
 
   return (
     <section id="hero" className={styles.hero} aria-label={hero.sectionAriaLabel}>
-      <HeroBackground />
+      <HeroBackdrop />
 
       <div ref={contentRef} className={styles.content}>
         <div className={styles.inner}>

--- a/components/homePage/homePage.test.tsx
+++ b/components/homePage/homePage.test.tsx
@@ -90,8 +90,11 @@ describe("Spline removal regressions", () => {
     const { container } = render(<HomePage locale="fr" />);
 
     // next/head is stubbed to a Fragment in jest.setup.ts, so head links render
-    // inline and are queryable here.
-    const hints = Array.from(container.querySelectorAll("link[rel='preconnect'], link[rel='dns-prefetch']"));
+    // inline and are queryable here. Scoped to the Spline origin on purpose: a
+    // legitimate preconnect added later must not fail a Spline regression test.
+    const hints = container.querySelectorAll(
+      "link[rel='preconnect'][href*='spline'], link[rel='dns-prefetch'][href*='spline']"
+    );
 
     expect(hints).toHaveLength(0);
   });

--- a/components/homePage/homePage.test.tsx
+++ b/components/homePage/homePage.test.tsx
@@ -1,0 +1,104 @@
+import fs from "fs";
+import path from "path";
+import React from "react";
+import { render, screen, within } from "@testing-library/react";
+import { HomePage } from "./homePage";
+import { getPortfolioContent } from "../../content/portfolioContent";
+
+const repoRoot = path.join(__dirname, "..", "..");
+const readFromRoot = (relativePath: string) =>
+  fs.readFileSync(path.join(repoRoot, relativePath), "utf8");
+
+describe("HomePage composition", () => {
+  it("renders the hero first and the projects band outside the light container", () => {
+    const { container } = render(<HomePage locale="fr" />);
+
+    const main = container.querySelector("#main-content") as HTMLElement;
+    expect(main.firstElementChild).toHaveAttribute("id", "hero");
+
+    // identity-obj-proxy maps CSS-module classes to their own name, so the light
+    // wrapper is reachable as `#main-content > .container`.
+    const lightContainer = main.querySelector(":scope > .container") as HTMLElement;
+    expect(lightContainer).not.toBeNull();
+    expect(lightContainer.querySelector("#projects")).toBeNull();
+
+    // …and the section is still on the page, as a full-bleed sibling.
+    expect(main.querySelector(":scope > #projects")).not.toBeNull();
+  });
+
+  it("keeps the hero and projects navigation anchors resolvable", () => {
+    const { container } = render(<HomePage locale="fr" />);
+
+    expect(container.querySelector("#hero")).not.toBeNull();
+    expect(container.querySelector("#projects")).not.toBeNull();
+
+    const navigation = screen.getByRole("navigation", {
+      name: getPortfolioContent("fr").navigation.mainNavAriaLabel,
+    });
+    expect(within(navigation).getByRole("link", { name: "Projets" })).toHaveAttribute(
+      "href",
+      "#projects"
+    );
+  });
+
+  it("keeps the hero and projects copy in parity across locales", () => {
+    (["fr", "en"] as const).forEach((locale) => {
+      const content = getPortfolioContent(locale);
+      const { container, unmount } = render(<HomePage locale={locale} />);
+
+      expect(screen.getByRole("heading", { level: 1, name: content.hero.name })).toBeVisible();
+
+      const projects = container.querySelector("#projects") as HTMLElement;
+      expect(within(projects).getByRole("heading", { level: 2 })).toHaveTextContent(
+        content.projects.title
+      );
+      expect(within(projects).getAllByRole("heading", { level: 3 })).toHaveLength(
+        content.projects.items.length
+      );
+      expect(within(projects).getAllByText(content.projects.disclosureLabel)).toHaveLength(
+        content.projects.items.length
+      );
+
+      unmount();
+    });
+  });
+});
+
+describe("Spline removal regressions", () => {
+  it("declares no Spline dependency", () => {
+    const packageJson = JSON.parse(readFromRoot("package.json"));
+    const declared = Object.keys({
+      ...packageJson.dependencies,
+      ...packageJson.devDependencies,
+    });
+
+    expect(declared.filter((name) => name.includes("spline"))).toHaveLength(0);
+  });
+
+  it("omits 'wasm-unsafe-eval' and the Spline origin from the CSP", () => {
+    const nextConfig = readFromRoot("next.config.js");
+    const directives = nextConfig.match(/"(script-src|connect-src)[^"]*"/g) ?? [];
+
+    expect(directives).toHaveLength(2);
+    directives.forEach((directive) => {
+      expect(directive).not.toContain("wasm-unsafe-eval");
+      expect(directive).not.toContain("prod.spline.design");
+    });
+  });
+
+  it("emits no Spline preconnect or dns-prefetch in the head", () => {
+    const { container } = render(<HomePage locale="fr" />);
+
+    // next/head is stubbed to a Fragment in jest.setup.ts, so head links render
+    // inline and are queryable here.
+    const hints = Array.from(container.querySelectorAll("link[rel='preconnect'], link[rel='dns-prefetch']"));
+
+    expect(hints).toHaveLength(0);
+  });
+
+  it("mounts no canvas anywhere on the page", () => {
+    const { container } = render(<HomePage locale="fr" />);
+
+    expect(container.querySelector("canvas")).toBeNull();
+  });
+});

--- a/components/homePage/homePage.tsx
+++ b/components/homePage/homePage.tsx
@@ -40,10 +40,14 @@ export function HomePage({ locale }: HomePageProps) {
             <SectionWorkExperiences locale={locale} />
             <Hr />
             <SectionEducations locale={locale} />
-            <Hr />
-            <SectionProjects locale={locale} />
           </div>
         </div>
+        {/*
+          Projects and Contact both render outside the light container: they are
+          full-bleed dark bands that close the page. The <Hr /> that used to
+          precede Projects is gone — the surface change now carries the break.
+        */}
+        <SectionProjects locale={locale} />
         <SectionContact locale={locale} />
       </main>
     </Layout>

--- a/components/layout/layout.tsx
+++ b/components/layout/layout.tsx
@@ -165,11 +165,6 @@ export function Layout({
             <Head>
                 <meta charSet="utf-8" />
 
-                {/*
-                  No third-party origin is warmed up here: the hero is CSS-only
-                  since #68, so the page loads nothing cross-origin at first paint.
-                */}
-
                 <meta name="author" content="Valentin PASSE" />
                 <meta name="copyright" content="Portfolio of Valentin PASSE" />
                 <meta

--- a/components/layout/layout.tsx
+++ b/components/layout/layout.tsx
@@ -166,19 +166,9 @@ export function Layout({
                 <meta charSet="utf-8" />
 
                 {/*
-                  Warm up the cross-origin connection to prod.spline.design as early
-                  as possible in the head: the 3D hero (home pages only) loads the
-                  Spline WebGL runtime + a remote scene from there at first paint.
-                  crossOrigin is required so the preconnected socket is reused for the
-                  scene's CORS fetch; dns-prefetch is a legacy fallback. Skipped on
-                  secondary pages (legal), which never render the hero.
+                  No third-party origin is warmed up here: the hero is CSS-only
+                  since #68, so the page loads nothing cross-origin at first paint.
                 */}
-                {!secondary && (
-                    <>
-                        <link rel="preconnect" href="https://prod.spline.design" crossOrigin="anonymous" />
-                        <link rel="dns-prefetch" href="https://prod.spline.design" />
-                    </>
-                )}
 
                 <meta name="author" content="Valentin PASSE" />
                 <meta name="copyright" content="Portfolio of Valentin PASSE" />

--- a/components/sectionProjects/sectionProjects.module.scss
+++ b/components/sectionProjects/sectionProjects.module.scss
@@ -1,116 +1,330 @@
+/*
+  Registering the angle is what makes it animatable — an unregistered custom
+  property can only be swapped discretely, never interpolated. Browsers without
+  `@property` (Firefox < 128, older Safari) leave `--hologram-angle` unset,
+  which makes the `conic-gradient` below invalid at computed-value time: the
+  `::after` simply paints nothing and the card keeps its real 1px border. Card
+  legibility never depends on this effect.
+*/
+@property --hologram-angle {
+	syntax: "<angle>";
+	initial-value: 0deg;
+	inherits: false;
+}
+
+@keyframes hologramBorderSpin {
+	to {
+		--hologram-angle: 360deg;
+	}
+}
+
+/* ---- Dark band ----------------------------------------------------------- */
+
 .section {
 	width: 100%;
-	padding: 6rem 1.25rem;
+	padding: 7rem 1.25rem;
+	color: var(--color-on-dark);
+	/*
+	  Runs from `--color-dark-2` down to `--color-dark` so the band closes on the
+	  exact tone `SectionContact` opens with: the two dark sections read as one
+	  continuous close to the page, with a single crisp edge against the light
+	  sections above.
+	*/
 	background:
-		radial-gradient(circle at 14% 10%, color-mix(in srgb, var(--color-accent) 8%, transparent), transparent 24%),
-		linear-gradient(180deg, var(--color-background) 0%, var(--color-card) 100%);
+		radial-gradient(circle at 12% 6%, color-mix(in srgb, var(--color-accent) 20%, transparent), transparent 38%),
+		radial-gradient(circle at 88% 88%, color-mix(in srgb, var(--color-accent-strong) 14%, transparent), transparent 42%),
+		linear-gradient(180deg, var(--color-dark-2) 0%, var(--color-dark) 100%);
 }
 
 .container {
-	max-width: 1140px;
+	max-width: 1240px;
 	margin: 0 auto;
 }
 
 .header {
 	max-width: 760px;
-	margin-bottom: 2rem;
+	margin-bottom: 2.4rem;
 }
 
 .title {
 	margin: 0;
-	color: var(--color-foreground);
+	color: var(--color-on-dark);
 	font-family: var(--font-display);
-	font-size: clamp(2.2rem, 3vw, 3.2rem);
+	font-size: clamp(2.2rem, 3.4vw, 3.4rem);
 	letter-spacing: -0.03em;
 }
 
 .subtitle {
 	margin: 0.85rem 0 0;
-	color: var(--color-text-muted);
-	line-height: 1.65;
+	color: var(--color-on-dark-muted);
+	line-height: 1.7;
 	font-size: 1.02rem;
 }
 
+/* ---- Bento grid ---------------------------------------------------------- */
+
 .grid {
 	display: grid;
-	grid-template-columns: repeat(3, minmax(0, 1fr));
-	gap: 1.15rem;
+	grid-template-columns: 1fr;
+	gap: 1.1rem;
 }
 
 .card {
-	display: flex;
-	flex-direction: column;
-	gap: 0.6rem;
-	border: 1px solid var(--color-border);
-	border-radius: 24px;
-	background: var(--color-card);
-	box-shadow: 0 18px 44px color-mix(in srgb, var(--color-foreground) 6%, transparent);
-	padding: 1.2rem;
+	position: relative;
+	border-radius: var(--radius-xl);
+	border: 1px solid var(--color-on-dark-border);
+	background:
+		linear-gradient(
+			160deg,
+			color-mix(in srgb, var(--color-on-dark) 7%, transparent) 0%,
+			color-mix(in srgb, var(--color-on-dark) 3%, transparent) 100%
+		),
+		var(--color-dark-2);
+	box-shadow: 0 24px 60px color-mix(in srgb, var(--color-dark-2) 55%, transparent);
+	/*
+	  Capped at 6°: enough to register as a response, restrained enough to stay
+	  professional. `--tilt-x` / `--tilt-y` are written by usePointerHologram and
+	  default to 0, so the card is perfectly flat until a fine pointer enters it.
+	*/
+	transform: perspective(900px) rotateX(calc(var(--tilt-y, 0) * -6deg))
+		rotateY(calc(var(--tilt-x, 0) * 6deg));
+	transition: transform 0.25s ease, border-color 0.25s ease;
 }
 
+/* Cursor spotlight. */
 .card::before {
 	content: "";
-	width: 72px;
-	height: 4px;
-	border-radius: 999px;
-	background: linear-gradient(90deg, var(--color-accent) 0%, var(--color-accent-strong) 100%);
+	position: absolute;
+	inset: 0;
+	border-radius: inherit;
+	pointer-events: none;
+	opacity: 0;
+	transition: opacity 0.25s ease;
+	background: radial-gradient(
+		600px circle at var(--mx, 50%) var(--my, 50%),
+		color-mix(in srgb, var(--color-accent) 14%, transparent),
+		transparent 45%
+	);
+}
+
+/*
+  Animated accent edge: a conic gradient revealed as a 1px ring through a
+  padding-box / border-box mask sandwich.
+*/
+.card::after {
+	content: "";
+	position: absolute;
+	inset: -1px;
+	border-radius: inherit;
+	padding: 1px;
+	pointer-events: none;
+	opacity: 0;
+	transition: opacity 0.3s ease;
+	background: conic-gradient(
+		from var(--hologram-angle),
+		transparent 0deg,
+		var(--color-accent-on-dark) 90deg,
+		transparent 180deg
+	);
+	-webkit-mask:
+		linear-gradient(#000 0 0) content-box,
+		linear-gradient(#000 0 0);
+	mask:
+		linear-gradient(#000 0 0) content-box,
+		linear-gradient(#000 0 0);
+	-webkit-mask-composite: xor;
+	mask-composite: exclude;
+}
+
+/*
+  Both effects are gated on a hover-capable fine pointer, mirroring the binding
+  guard in usePointerHologram: on touch, `:hover` sticks after a tap and would
+  leave a card permanently lit.
+
+  The border spin is deliberately scoped to the hovered/focused card rather than
+  left running: animating a custom property inside a gradient repaints every
+  frame, so keeping three cards spinning permanently would trade the WebGL cost
+  this redesign removes for a cheaper — but still pointless — one.
+*/
+@media (hover: hover) and (pointer: fine) {
+	.card:hover::before,
+	.card:focus-within::before {
+		opacity: 1;
+	}
+
+	.card:hover::after,
+	.card:focus-within::after {
+		opacity: 1;
+		animation: hologramBorderSpin 6s linear infinite;
+	}
+
+	.card:hover,
+	.card:focus-within {
+		border-color: color-mix(in srgb, var(--color-accent-on-dark) 34%, transparent);
+	}
+}
+
+.cardContent {
+	position: relative;
+	/* Above the spotlight overlay. */
+	z-index: 1;
+	height: 100%;
+	display: flex;
+	flex-direction: column;
+	gap: 0.75rem;
+	padding: 1.6rem;
 }
 
 .cardTitle {
 	margin: 0;
-	color: var(--color-foreground);
-	font-size: 1.12rem;
+	color: var(--color-on-dark);
+	font-family: var(--font-display);
+	font-size: 1.2rem;
+	line-height: 1.25;
+	letter-spacing: -0.01em;
 }
 
 .summary {
 	margin: 0;
-	color: var(--color-text-muted);
-	line-height: 1.6;
+	color: var(--color-on-dark-muted);
+	line-height: 1.65;
 }
 
-.blockLabel {
-	margin: 0.35rem 0 0;
-	color: var(--color-foreground);
+/* ---- Outcome: the proof line, never behind an interaction ---------------- */
+
+.outcome {
+	margin: 0.2rem 0 0;
+	padding: 0.9rem 1rem;
+	border-radius: var(--radius-lg);
+	border: 1px solid color-mix(in srgb, var(--color-accent-on-dark) 22%, transparent);
+	background: color-mix(in srgb, var(--color-accent-on-dark) 7%, transparent);
+	display: flex;
+	flex-direction: column;
+	gap: 0.35rem;
+}
+
+.outcomeLabel {
+	color: var(--color-accent-on-dark);
+	font-size: 0.76rem;
 	font-weight: 700;
-	font-size: 0.86rem;
+	letter-spacing: 0.14em;
 	text-transform: uppercase;
-	letter-spacing: 0.03em;
 }
 
-.blockText {
-	margin: 0;
-	color: var(--color-text-muted);
-	line-height: 1.58;
-	font-size: 0.92rem;
+.outcomeText {
+	color: var(--color-on-dark);
+	line-height: 1.6;
+	font-size: 0.95rem;
 }
+
+/* ---- Tags ---------------------------------------------------------------- */
 
 .tags {
-	margin: 0.45rem 0 0;
+	margin: 0.15rem 0 0;
 	padding: 0;
 	list-style: none;
 	display: flex;
 	flex-wrap: wrap;
-	gap: 0.42rem;
+	gap: 0.4rem;
 }
 
 .tag {
 	border-radius: 999px;
-	border: 1px solid var(--color-border);
-	background: var(--color-background-alt);
-	color: var(--color-text);
-	padding: 0.24rem 0.58rem;
-	font-size: 0.81rem;
+	border: 1px solid var(--color-on-dark-border);
+	background: color-mix(in srgb, var(--color-on-dark) 8%, transparent);
+	color: var(--color-on-dark);
+	padding: 0.26rem 0.62rem;
+	font-size: 0.8rem;
+}
+
+/* ---- Disclosure ---------------------------------------------------------- */
+
+.details {
+	/* Pins the control to the bottom of the taller featured card. */
+	margin-top: auto;
+	padding-top: 0.5rem;
+}
+
+.disclosure {
+	display: flex;
+	align-items: center;
+	gap: 0.55rem;
+	min-height: 44px;
+	cursor: pointer;
+	color: var(--color-accent-on-dark);
+	font-size: 0.92rem;
+	font-weight: 600;
+	/* Drop the default triangle in favour of the chevron below. */
+	list-style: none;
+
+	&::-webkit-details-marker {
+		display: none;
+	}
+
+	&::after {
+		content: "";
+		width: 0.5rem;
+		height: 0.5rem;
+		border-right: 2px solid currentColor;
+		border-bottom: 2px solid currentColor;
+		transform: translateY(-2px) rotate(45deg);
+		transition: transform 0.2s ease;
+	}
+
+	&:focus-visible {
+		outline: 2px solid var(--color-accent-on-dark);
+		outline-offset: 3px;
+		border-radius: 6px;
+	}
+}
+
+.details[open] .disclosure::after {
+	transform: translateY(1px) rotate(-135deg);
+}
+
+.detailsBody {
+	display: flex;
+	flex-direction: column;
+	gap: 0.3rem;
+	padding-top: 0.4rem;
+}
+
+.blockLabel {
+	margin: 0.35rem 0 0;
+	color: var(--color-on-dark);
+	font-weight: 700;
+	font-size: 0.78rem;
+	text-transform: uppercase;
+	letter-spacing: 0.1em;
+}
+
+.blockText {
+	margin: 0;
+	color: var(--color-on-dark-muted);
+	line-height: 1.6;
+	font-size: 0.9rem;
 }
 
 .link {
-	margin-top: auto;
-	color: var(--color-foreground);
+	margin-top: 0.4rem;
+	display: inline-flex;
+	align-items: center;
+	min-height: 44px;
+	color: var(--color-accent-on-dark);
 	font-weight: 600;
-	text-underline-offset: 2px;
+	text-decoration: underline;
+	text-underline-offset: 3px;
+
+	&:focus-visible {
+		outline: 2px solid var(--color-accent-on-dark);
+		outline-offset: 3px;
+	}
 }
 
+/* ---- Section CTAs -------------------------------------------------------- */
+
 .ctaRow {
-	margin-top: 1.2rem;
+	margin-top: 2rem;
 	display: flex;
 	flex-wrap: wrap;
 	gap: 0.75rem;
@@ -125,36 +339,119 @@
 	border-radius: 999px;
 	font-weight: 600;
 	text-decoration: none;
-	padding: 0.75rem 1rem;
+	padding: 0.8rem 1.4rem;
+	transition: transform 0.15s ease, background-color 0.2s ease, border-color 0.2s ease;
+
+	&:focus-visible {
+		outline: 2px solid var(--color-accent-on-dark);
+		outline-offset: 3px;
+	}
+
+	&:hover {
+		transform: translateY(-2px);
+	}
 }
 
 .primaryCta {
 	background: var(--color-accent);
 	color: var(--color-on-accent);
+
+	&:hover {
+		background: var(--color-accent-strong);
+	}
 }
 
 .secondaryCta {
-	background: var(--color-card);
-	color: var(--color-foreground);
-	border: 1px solid var(--color-border);
+	background-color: color-mix(in srgb, var(--color-on-dark) 8%, transparent);
+	color: var(--color-on-dark);
+	border: 1px solid var(--color-on-dark-border);
+
+	&:hover {
+		border-color: var(--color-on-dark);
+	}
 }
 
-@media (max-width: 1024px) {
+/* ---- Responsive ---------------------------------------------------------- */
+
+@media (min-width: 768px) {
 	.grid {
 		grid-template-columns: repeat(2, minmax(0, 1fr));
+	}
+
+	.cardFeatured {
+		grid-column: span 2;
+	}
+
+	.cardFeatured .cardTitle {
+		font-size: 1.6rem;
+	}
+
+	.cardFeatured .summary {
+		font-size: 1.06rem;
+	}
+
+	.cardContent {
+		padding: 1.8rem;
+	}
+}
+
+@media (min-width: 1024px) {
+	.grid {
+		grid-template-columns: repeat(3, minmax(0, 1fr));
+		/* Explicit rows: the track count never depends on content, so expanding a
+		   disclosure cannot re-flow the bento into a different shape. */
+		grid-template-rows: repeat(2, minmax(0, auto));
+	}
+
+	.cardFeatured {
+		grid-column: span 2;
+		grid-row: span 2;
+	}
+
+	.cardFeatured .cardContent {
+		padding: 2.2rem;
 	}
 }
 
 @media (max-width: 700px) {
 	.section {
-		padding: 3.5rem 1rem;
-	}
-
-	.grid {
-		grid-template-columns: 1fr;
+		padding: 4rem 1rem;
 	}
 
 	.ctaRow {
 		flex-direction: column;
+	}
+
+	.primaryCta,
+	.secondaryCta {
+		width: 100%;
+	}
+}
+
+@media (prefers-reduced-motion: reduce) {
+	.card {
+		transform: none;
+		transition: none;
+	}
+
+	.card::before,
+	.card::after,
+	.card:hover::before,
+	.card:hover::after,
+	.card:focus-within::before,
+	.card:focus-within::after {
+		opacity: 0;
+		animation: none;
+	}
+
+	.disclosure::after,
+	.primaryCta,
+	.secondaryCta {
+		transition: none;
+	}
+
+	.primaryCta:hover,
+	.secondaryCta:hover {
+		transform: none;
 	}
 }

--- a/components/sectionProjects/sectionProjects.module.scss
+++ b/components/sectionProjects/sectionProjects.module.scss
@@ -12,7 +12,18 @@
 	inherits: false;
 }
 
+/*
+  Both stops render an identical gradient, which matters for the fallback:
+  without `@property` the custom property is unregistered, so this interpolates
+  discretely — it flips straight from one stop to the other. Making the two
+  endpoints visually equal turns that flip into a no-op instead of a border
+  blinking in and out every few seconds.
+*/
 @keyframes hologramBorderSpin {
+	from {
+		--hologram-angle: 0deg;
+	}
+
 	to {
 		--hologram-angle: 360deg;
 	}
@@ -81,14 +92,6 @@
 		),
 		var(--color-dark-2);
 	box-shadow: 0 24px 60px color-mix(in srgb, var(--color-dark-2) 55%, transparent);
-	/*
-	  Capped at 6°: enough to register as a response, restrained enough to stay
-	  professional. `--tilt-x` / `--tilt-y` are written by usePointerHologram and
-	  default to 0, so the card is perfectly flat until a fine pointer enters it.
-	*/
-	transform: perspective(900px) rotateX(calc(var(--tilt-y, 0) * -6deg))
-		rotateY(calc(var(--tilt-x, 0) * 6deg));
-	transition: transform 0.25s ease, border-color 0.25s ease;
 }
 
 /* Cursor spotlight. */
@@ -147,6 +150,21 @@
   this redesign removes for a cheaper — but still pointless — one.
 */
 @media (hover: hover) and (pointer: fine) {
+	/*
+	  Capped at 6°: enough to register as a response, restrained enough to stay
+	  professional. `--tilt-x` / `--tilt-y` are written by usePointerHologram and
+	  default to 0, so the card is flat until the pointer enters it.
+
+	  Declared here rather than on `.card` so coarse-pointer devices — where the
+	  tilt can never happen — never pay for a 3D rendering context and its
+	  per-card composited layer.
+	*/
+	.card {
+		transform: perspective(900px) rotateX(calc(var(--tilt-y, 0) * -6deg))
+			rotateY(calc(var(--tilt-x, 0) * 6deg));
+		transition: transform 0.25s ease, border-color 0.25s ease;
+	}
+
 	.card:hover::before,
 	.card:focus-within::before {
 		opacity: 1;
@@ -398,8 +416,13 @@
 @media (min-width: 1024px) {
 	.grid {
 		grid-template-columns: repeat(3, minmax(0, 1fr));
-		/* Explicit rows: the track count never depends on content, so expanding a
-		   disclosure cannot re-flow the bento into a different shape. */
+		/*
+		  Explicit rows: the track *count* never depends on content, so the bento
+		  keeps its shape whatever the cards contain. Track *height* still follows
+		  content — expanding a disclosure grows its row and pushes what sits below
+		  down, exactly as any native <details> does. Cards sharing a row keep their
+		  position.
+		*/
 		grid-template-rows: repeat(2, minmax(0, auto));
 	}
 

--- a/components/sectionProjects/sectionProjects.test.tsx
+++ b/components/sectionProjects/sectionProjects.test.tsx
@@ -1,0 +1,283 @@
+import React from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { SectionProjects } from "./sectionProjects";
+import { getPortfolioContent } from "../../content/portfolioContent";
+
+jest.mock("../../content/portfolioContent", () => {
+  const actual = jest.requireActual("../../content/portfolioContent");
+  return { ...actual, getPortfolioContent: jest.fn(actual.getPortfolioContent) };
+});
+
+const getPortfolioContentMock = getPortfolioContent as jest.MockedFunction<
+  typeof getPortfolioContent
+>;
+
+const frContent = jest
+  .requireActual<typeof import("../../content/portfolioContent")>("../../content/portfolioContent")
+  .getPortfolioContent("fr");
+const frProjects = frContent.projects;
+
+/**
+ * jsdom has no media queries; each test declares which ones match so the
+ * binding guards of usePointerHologram can be exercised for real.
+ */
+function mockMatchMedia(matcher: (query: string) => boolean) {
+  // jest.setup.ts installs matchMedia as writable but not configurable, so it is
+  // reassigned rather than redefined.
+  window.matchMedia = ((query: string) => ({
+    matches: matcher(query),
+    media: query,
+    onchange: null,
+    addListener: () => undefined,
+    removeListener: () => undefined,
+    addEventListener: () => undefined,
+    removeEventListener: () => undefined,
+    dispatchEvent: () => false,
+  })) as unknown as typeof window.matchMedia;
+}
+
+const FINE_POINTER = (query: string) => query === "(hover: hover) and (pointer: fine)";
+const COARSE_POINTER = () => false;
+const REDUCED_MOTION = (query: string) =>
+  query === "(prefers-reduced-motion: reduce)" || FINE_POINTER(query);
+
+/**
+ * jsdom implements neither PointerEvent nor the mouse coordinate properties on
+ * a bare Event, so the payload is attached explicitly instead of relying on an
+ * event-init the constructor would silently drop.
+ */
+function firePointer(
+  target: Element,
+  type: "pointermove" | "pointerleave",
+  payload: Record<string, unknown> = {}
+) {
+  const event = new Event(type, { bubbles: type === "pointermove" });
+  Object.assign(event, payload);
+  fireEvent(target, event);
+}
+
+function firstCard() {
+  return document.querySelector("[data-hologram-card]") as HTMLElement;
+}
+
+describe("SectionProjects", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+    getPortfolioContentMock.mockImplementation(
+      jest.requireActual<typeof import("../../content/portfolioContent")>(
+        "../../content/portfolioContent"
+      ).getPortfolioContent
+    );
+    mockMatchMedia(() => false);
+  });
+
+  describe("content exposure", () => {
+    beforeEach(() => mockMatchMedia(FINE_POINTER));
+
+    it("exposes every title, summary and outcome without any interaction", () => {
+      render(<SectionProjects locale="fr" />);
+
+      frProjects.items.forEach((project) => {
+        expect(screen.getByRole("heading", { level: 3, name: project.title })).toBeVisible();
+        expect(screen.getByText(project.summary)).toBeVisible();
+        expect(screen.getByText(project.outcome)).toBeVisible();
+      });
+    });
+
+    it("keeps context and contribution in the document while the disclosure is collapsed", () => {
+      render(<SectionProjects locale="fr" />);
+
+      const [firstProject] = frProjects.items;
+      const details = screen.getAllByText(frProjects.disclosureLabel)[0].closest("details");
+      expect(details).not.toHaveAttribute("open");
+
+      // Collapsed, not removed: the copy stays crawlable.
+      expect(screen.getByText(firstProject.context)).toBeInTheDocument();
+      expect(screen.getByText(firstProject.contribution)).toBeInTheDocument();
+    });
+
+    it("exposes the expanded state when a disclosure is toggled", () => {
+      render(<SectionProjects locale="fr" />);
+
+      const summary = screen.getAllByText(frProjects.disclosureLabel)[0];
+      const details = summary.closest("details") as HTMLDetailsElement;
+      expect(details).not.toHaveAttribute("open");
+
+      fireEvent.click(summary);
+
+      expect(details).toHaveAttribute("open");
+    });
+
+    it("renders the section CTAs and one labelled tag list per project", () => {
+      render(<SectionProjects locale="fr" />);
+
+      expect(
+        screen.getByRole("link", { name: frProjects.primaryAction.label })
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("link", { name: frProjects.secondaryAction.label })
+      ).toBeInTheDocument();
+      expect(screen.getAllByLabelText(frProjects.tagsAriaLabel)).toHaveLength(
+        frProjects.items.length
+      );
+    });
+
+    it("does not render a project missing its title or its summary", () => {
+      getPortfolioContentMock.mockReturnValue({
+        ...frContent,
+        projects: {
+          ...frProjects,
+          items: [
+            frProjects.items[0],
+            { ...frProjects.items[1], title: "  " },
+            { ...frProjects.items[2], summary: "" },
+          ],
+        },
+      });
+
+      render(<SectionProjects locale="fr" />);
+
+      expect(screen.getAllByRole("heading", { level: 3 })).toHaveLength(1);
+      expect(document.querySelectorAll("[data-hologram-card]")).toHaveLength(1);
+    });
+
+    it("stays in parity on the English route", () => {
+      const enProjects = getPortfolioContent("en").projects;
+      render(<SectionProjects locale="en" />);
+
+      expect(screen.getAllByRole("heading", { level: 3 })).toHaveLength(enProjects.items.length);
+      expect(screen.getAllByText(enProjects.disclosureLabel)).toHaveLength(enProjects.items.length);
+      enProjects.items.forEach((project) => {
+        expect(screen.getByText(project.outcome)).toBeVisible();
+      });
+    });
+  });
+
+  describe("external links", () => {
+    beforeEach(() => mockMatchMedia(FINE_POINTER));
+
+    it("emits no external link when no project declares a public one", () => {
+      // Guards the confidentiality constraint: none of the three engagements has
+      // a publishable URL today, so the section must stay link-free.
+      expect(frProjects.items.every((project) => !project.publicLink)).toBe(true);
+
+      render(<SectionProjects locale="fr" />);
+
+      expect(
+        screen.queryByRole("link", { name: frProjects.externalLinkLabel })
+      ).not.toBeInTheDocument();
+    });
+
+    it("renders a hardened, labelled link for a project declaring a public one", () => {
+      const project = frProjects.items[0];
+      getPortfolioContentMock.mockReturnValue({
+        ...frContent,
+        projects: {
+          ...frProjects,
+          items: [{ ...project, publicLink: "https://example.com" }],
+        },
+      });
+
+      render(<SectionProjects locale="fr" />);
+
+      const link = screen.getByRole("link", {
+        name: frProjects.externalLinkAriaTemplate.replace("{title}", project.title),
+      });
+      expect(link).toHaveAttribute("href", "https://example.com");
+      expect(link).toHaveAttribute("rel", "noopener noreferrer");
+      expect(link).toHaveAttribute("target", "_blank");
+    });
+  });
+
+  describe("pointer hologram binding guards", () => {
+    // React delegates its own pointermove listener on the test root, which also
+    // contains the cards; only the element that directly parents them is ours.
+    const isGrid = (node: unknown): node is HTMLElement =>
+      node instanceof HTMLElement &&
+      node.firstElementChild?.hasAttribute("data-hologram-card") === true;
+
+    function countPointerBindings() {
+      const addEventListener = jest.spyOn(EventTarget.prototype, "addEventListener");
+      render(<SectionProjects locale="fr" />);
+      return addEventListener.mock.calls.filter(
+        ([type], index) => type === "pointermove" && isGrid(addEventListener.mock.instances[index])
+      ).length;
+    }
+
+    it("binds no pointer listener on a coarse pointer", () => {
+      mockMatchMedia(COARSE_POINTER);
+
+      expect(countPointerBindings()).toBe(0);
+    });
+
+    it("binds no pointer listener under prefers-reduced-motion", () => {
+      mockMatchMedia(REDUCED_MOTION);
+
+      expect(countPointerBindings()).toBe(0);
+    });
+
+    it("binds a single delegated listener on a fine pointer", () => {
+      mockMatchMedia(FINE_POINTER);
+
+      // One listener for the whole grid — never one per card.
+      expect(countPointerBindings()).toBe(1);
+    });
+  });
+
+  describe("pointer hologram writes", () => {
+    beforeEach(() => mockMatchMedia(FINE_POINTER));
+
+    it("coalesces a burst of moves into a single frame and writes the last position", () => {
+      render(<SectionProjects locale="fr" />);
+
+      const frames: FrameRequestCallback[] = [];
+      jest
+        .spyOn(window, "requestAnimationFrame")
+        .mockImplementation((callback: FrameRequestCallback) => {
+          frames.push(callback);
+          return frames.length;
+        });
+
+      const card = firstCard();
+      const grid = card.parentElement as HTMLElement;
+      jest.spyOn(card, "getBoundingClientRect").mockReturnValue({
+        left: 0,
+        top: 0,
+        width: 200,
+        height: 100,
+      } as DOMRect);
+
+      firePointer(card, "pointermove", { clientX: 10, clientY: 10, pointerType: "mouse" });
+      firePointer(card, "pointermove", { clientX: 50, clientY: 50, pointerType: "mouse" });
+      firePointer(card, "pointermove", { clientX: 150, clientY: 75, pointerType: "mouse" });
+
+      // One frame for three moves — never one style write per event.
+      expect(frames).toHaveLength(1);
+
+      frames[0](0);
+
+      expect(card.style.getPropertyValue("--mx")).toBe("75.00%");
+      expect(card.style.getPropertyValue("--my")).toBe("75.00%");
+      expect(card.style.getPropertyValue("--tilt-x")).toBe("0.2500");
+      expect(card.style.getPropertyValue("--tilt-y")).toBe("0.2500");
+
+      // Leaving the grid clears the card so it never stays tilted.
+      firePointer(grid, "pointerleave");
+      expect(card.style.getPropertyValue("--mx")).toBe("");
+      expect(card.style.getPropertyValue("--tilt-x")).toBe("");
+    });
+
+    it("ignores touch-originated moves on hybrid devices", () => {
+      render(<SectionProjects locale="fr" />);
+
+      const requestAnimationFrame = jest.spyOn(window, "requestAnimationFrame");
+      firePointer(firstCard(), "pointermove", {
+        clientX: 10,
+        clientY: 10,
+        pointerType: "touch",
+      });
+
+      expect(requestAnimationFrame).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/components/sectionProjects/sectionProjects.test.tsx
+++ b/components/sectionProjects/sectionProjects.test.tsx
@@ -1,7 +1,14 @@
+import fs from "fs";
+import path from "path";
 import React from "react";
 import { fireEvent, render, screen } from "@testing-library/react";
 import { SectionProjects } from "./sectionProjects";
 import { getPortfolioContent } from "../../content/portfolioContent";
+import {
+  FINE_POINTER,
+  NO_PREFERENCE,
+  mockMatchMedia,
+} from "../../lib/testing/mockMatchMedia";
 
 jest.mock("../../content/portfolioContent", () => {
   const actual = jest.requireActual("../../content/portfolioContent");
@@ -17,28 +24,13 @@ const frContent = jest
   .getPortfolioContent("fr");
 const frProjects = frContent.projects;
 
-/**
- * jsdom has no media queries; each test declares which ones match so the
- * binding guards of usePointerHologram can be exercised for real.
- */
-function mockMatchMedia(matcher: (query: string) => boolean) {
-  // jest.setup.ts installs matchMedia as writable but not configurable, so it is
-  // reassigned rather than redefined.
-  window.matchMedia = ((query: string) => ({
-    matches: matcher(query),
-    media: query,
-    onchange: null,
-    addListener: () => undefined,
-    removeListener: () => undefined,
-    addEventListener: () => undefined,
-    removeEventListener: () => undefined,
-    dispatchEvent: () => false,
-  })) as unknown as typeof window.matchMedia;
-}
+const projectStyles = fs.readFileSync(
+  path.join(__dirname, "sectionProjects.module.scss"),
+  "utf8"
+);
 
-const FINE_POINTER = (query: string) => query === "(hover: hover) and (pointer: fine)";
-const COARSE_POINTER = () => false;
-const REDUCED_MOTION = (query: string) =>
+/** A hybrid machine: fine pointer available, but reduced motion requested. */
+const FINE_POINTER_REDUCED_MOTION = (query: string) =>
   query === "(prefers-reduced-motion: reduce)" || FINE_POINTER(query);
 
 /**
@@ -68,7 +60,7 @@ describe("SectionProjects", () => {
         "../../content/portfolioContent"
       ).getPortfolioContent
     );
-    mockMatchMedia(() => false);
+    mockMatchMedia(NO_PREFERENCE);
   });
 
   describe("content exposure", () => {
@@ -187,6 +179,27 @@ describe("SectionProjects", () => {
       expect(link).toHaveAttribute("rel", "noopener noreferrer");
       expect(link).toHaveAttribute("target", "_blank");
     });
+
+    it.each(["http://example.com", "/somewhere", "example.com", "javascript:alert(1)"])(
+      "never emits a link for the non-absolute-https value %s",
+      (publicLink) => {
+        getPortfolioContentMock.mockReturnValue({
+          ...frContent,
+          projects: {
+            ...frProjects,
+            items: [{ ...frProjects.items[0], publicLink }],
+          },
+        });
+
+        render(<SectionProjects locale="fr" />);
+
+        const externalLinkName = frProjects.externalLinkAriaTemplate.replace(
+          "{title}",
+          frProjects.items[0].title
+        );
+        expect(screen.queryByRole("link", { name: externalLinkName })).not.toBeInTheDocument();
+      }
+    );
   });
 
   describe("pointer hologram binding guards", () => {
@@ -200,18 +213,19 @@ describe("SectionProjects", () => {
       const addEventListener = jest.spyOn(EventTarget.prototype, "addEventListener");
       render(<SectionProjects locale="fr" />);
       return addEventListener.mock.calls.filter(
-        ([type], index) => type === "pointermove" && isGrid(addEventListener.mock.instances[index])
+        // `contexts` is the documented accessor for a call's `this`.
+        ([type], index) => type === "pointermove" && isGrid(addEventListener.mock.contexts[index])
       ).length;
     }
 
     it("binds no pointer listener on a coarse pointer", () => {
-      mockMatchMedia(COARSE_POINTER);
+      mockMatchMedia(NO_PREFERENCE);
 
       expect(countPointerBindings()).toBe(0);
     });
 
     it("binds no pointer listener under prefers-reduced-motion", () => {
-      mockMatchMedia(REDUCED_MOTION);
+      mockMatchMedia(FINE_POINTER_REDUCED_MOTION);
 
       expect(countPointerBindings()).toBe(0);
     });
@@ -278,6 +292,50 @@ describe("SectionProjects", () => {
       });
 
       expect(requestAnimationFrame).not.toHaveBeenCalled();
+    });
+  });
+
+  /*
+   * The CSS half of the guardrails. jsdom loads no stylesheet — CSS-module
+   * classes are mapped to their own name by identity-obj-proxy — so
+   * getComputedStyle would report nothing. Asserting on the source is the only
+   * lever available, and these rules are exactly the ones the issue calls
+   * non-negotiable.
+   */
+  describe("stylesheet guardrails", () => {
+    const reducedMotionBlock = projectStyles.match(
+      /^@media \(prefers-reduced-motion: reduce\) \{([\s\S]*?)^\}/m
+    )?.[1];
+
+    it("suppresses tilt, spotlight and border animation under prefers-reduced-motion", () => {
+      expect(reducedMotionBlock).toBeDefined();
+      expect(reducedMotionBlock).toMatch(/\.card \{[^}]*transform: none;/);
+      expect(reducedMotionBlock).toMatch(/opacity: 0;/);
+      expect(reducedMotionBlock).toMatch(/animation: none;/);
+    });
+
+    it("declares the reduced-motion override after the fine-pointer block, so it wins", () => {
+      // Same specificity: source order decides.
+      expect(projectStyles.indexOf("@media (prefers-reduced-motion: reduce)")).toBeGreaterThan(
+        projectStyles.indexOf("@media (hover: hover) and (pointer: fine)")
+      );
+    });
+
+    it("binds tilt only inside the fine-pointer block", () => {
+      const finePointerBlock = projectStyles.match(
+        /^@media \(hover: hover\) and \(pointer: fine\) \{([\s\S]*?)^\}/m
+      )?.[1];
+
+      expect(finePointerBlock).toMatch(/transform: perspective\(900px\)/);
+      // Capped at 6°, per the issue.
+      expect(finePointerBlock).toMatch(/\* -6deg/);
+      expect(finePointerBlock).toMatch(/\* 6deg/);
+      expect(projectStyles.match(/transform: perspective\(/g)).toHaveLength(1);
+    });
+
+    it("never uses --color-accent for text on the dark band", () => {
+      // #2563eb fails 4.5:1 here; accents must use --color-accent-on-dark.
+      expect(projectStyles).not.toMatch(/(^|[^-])color:\s*var\(--color-accent\)/m);
     });
   });
 });

--- a/components/sectionProjects/sectionProjects.tsx
+++ b/components/sectionProjects/sectionProjects.tsx
@@ -1,5 +1,6 @@
-import React from "react";
+import React, { useRef } from "react";
 import { PortfolioLocale, getPortfolioContent } from "../../content/portfolioContent";
+import { usePointerHologram } from "./usePointerHologram";
 import styles from "./sectionProjects.module.scss";
 
 type SectionProjectsProps = {
@@ -8,6 +9,15 @@ type SectionProjectsProps = {
 
 export function SectionProjects({ locale = "fr" }: SectionProjectsProps) {
   const content = getPortfolioContent(locale).projects;
+  const gridRef = useRef<HTMLDivElement>(null);
+
+  usePointerHologram(gridRef);
+
+  // A project missing its title or its summary would render as an empty cell in
+  // the bento; drop it rather than punch a hole in the grid.
+  const projects = content.items.filter(
+    (project) => project.title?.trim() && project.summary?.trim()
+  );
 
   return (
     <section id="projects" className={styles.section} aria-labelledby="projects-title">
@@ -19,40 +29,65 @@ export function SectionProjects({ locale = "fr" }: SectionProjectsProps) {
           <p className={styles.subtitle}>{content.subtitle}</p>
         </header>
 
-        <div className={styles.grid}>
-          {content.items.map((project) => (
-            <article key={project.title} className={styles.card}>
-              <h3 className={styles.cardTitle}>{project.title}</h3>
-              <p className={styles.summary}>{project.summary}</p>
+        <div ref={gridRef} className={styles.grid}>
+          {projects.map((project, index) => (
+            <article
+              key={project.title}
+              // Read by usePointerHologram to resolve the hovered card without
+              // depending on a hashed CSS-module class name.
+              data-hologram-card=""
+              className={index === 0 ? `${styles.card} ${styles.cardFeatured}` : styles.card}
+            >
+              <div className={styles.cardContent}>
+                <h3 className={styles.cardTitle}>{project.title}</h3>
+                <p className={styles.summary}>{project.summary}</p>
 
-              <p className={styles.blockLabel}>{content.contextLabel}</p>
-              <p className={styles.blockText}>{project.context}</p>
+                {/*
+                  Summary and outcome stay out of any disclosure on purpose: #38
+                  added verifiable outcomes for search and AI-citation value, so
+                  they must never sit behind an interaction.
+                */}
+                <p className={styles.outcome}>
+                  <span className={styles.outcomeLabel}>{content.outcomeLabel}</span>
+                  <span className={styles.outcomeText}>{project.outcome}</span>
+                </p>
 
-              <p className={styles.blockLabel}>{content.contributionLabel}</p>
-              <p className={styles.blockText}>{project.contribution}</p>
+                <ul className={styles.tags} aria-label={content.tagsAriaLabel}>
+                  {project.tags.map((tag) => (
+                    <li key={`${project.title}-${tag}`} className={styles.tag}>
+                      {tag}
+                    </li>
+                  ))}
+                </ul>
 
-              <p className={styles.blockLabel}>{content.outcomeLabel}</p>
-              <p className={styles.blockText}>{project.outcome}</p>
+                {/*
+                  Native <details>: keyboard operation and expanded-state
+                  announcement come for free, and the collapsed copy stays in the
+                  DOM, hence crawlable.
+                */}
+                <details className={styles.details}>
+                  <summary className={styles.disclosure}>{content.disclosureLabel}</summary>
+                  <div className={styles.detailsBody}>
+                    <p className={styles.blockLabel}>{content.contextLabel}</p>
+                    <p className={styles.blockText}>{project.context}</p>
 
-              <ul className={styles.tags} aria-label={content.tagsAriaLabel}>
-                {project.tags.map((tag) => (
-                  <li key={`${project.title}-${tag}`} className={styles.tag}>
-                    {tag}
-                  </li>
-                ))}
-              </ul>
+                    <p className={styles.blockLabel}>{content.contributionLabel}</p>
+                    <p className={styles.blockText}>{project.contribution}</p>
+                  </div>
+                </details>
 
-              {project.publicLink ? (
-                <a
-                  href={project.publicLink}
-                  className={styles.link}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  aria-label={content.externalLinkAriaTemplate.replace("{title}", project.title)}
-                >
-                  {content.externalLinkLabel}
-                </a>
-              ) : null}
+                {project.publicLink ? (
+                  <a
+                    href={project.publicLink}
+                    className={styles.link}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    aria-label={content.externalLinkAriaTemplate.replace("{title}", project.title)}
+                  >
+                    {content.externalLinkLabel}
+                  </a>
+                ) : null}
+              </div>
             </article>
           ))}
         </div>

--- a/components/sectionProjects/sectionProjects.tsx
+++ b/components/sectionProjects/sectionProjects.tsx
@@ -7,6 +7,15 @@ type SectionProjectsProps = {
   locale?: PortfolioLocale;
 };
 
+/**
+ * Only an absolute https URL may reach the markup: a relative one would resolve
+ * against the portfolio itself, and an http one would downgrade the connection
+ * on a link opened in a new tab.
+ */
+function isPublishableLink(url: string | undefined): url is string {
+  return typeof url === "string" && /^https:\/\/\S+$/.test(url.trim());
+}
+
 export function SectionProjects({ locale = "fr" }: SectionProjectsProps) {
   const content = getPortfolioContent(locale).projects;
   const gridRef = useRef<HTMLDivElement>(null);
@@ -76,7 +85,7 @@ export function SectionProjects({ locale = "fr" }: SectionProjectsProps) {
                   </div>
                 </details>
 
-                {project.publicLink ? (
+                {isPublishableLink(project.publicLink) ? (
                   <a
                     href={project.publicLink}
                     className={styles.link}

--- a/components/sectionProjects/usePointerHologram.ts
+++ b/components/sectionProjects/usePointerHologram.ts
@@ -1,0 +1,116 @@
+import { RefObject, useEffect } from "react";
+import { hasFinePointer, prefersReducedMotion } from "../../lib/mediaPreferences";
+
+/**
+ * Cards opt into pointer tracking through this attribute rather than a CSS
+ * module class, so the hook never depends on a hashed class name.
+ */
+const CARD_SELECTOR = "[data-hologram-card]";
+
+const TRACKED_PROPERTIES = ["--mx", "--my", "--tilt-x", "--tilt-y"] as const;
+
+/**
+ * Drives the holographic treatment of the projects grid: writes the pointer
+ * position (`--mx`, `--my`, in %) and the normalised offset from the card
+ * centre (`--tilt-x`, `--tilt-y`, in -0.5..0.5) onto the hovered card, where
+ * the stylesheet turns them into a spotlight and a capped 3D tilt.
+ *
+ * Three constraints shape the implementation:
+ *
+ *  - **One listener, not one per card.** The `pointermove` handler is delegated
+ *    on the grid container and resolves the hovered card with `closest()`.
+ *  - **One write per frame.** Moves only record their coordinates; a single
+ *    `requestAnimationFrame` flushes them, so a fast pointer never queues
+ *    redundant style work.
+ *  - **Never bound where it does not belong.** Nothing is attached under
+ *    `prefers-reduced-motion: reduce`, nor on coarse pointers, where a tilt
+ *    would only leave cards stuck in a hovered state after a tap.
+ */
+export function usePointerHologram(gridRef: RefObject<HTMLElement | null>): void {
+  useEffect(() => {
+    const grid = gridRef.current;
+    if (!grid || prefersReducedMotion() || !hasFinePointer()) {
+      return;
+    }
+
+    let frame: number | null = null;
+    let pending: { card: HTMLElement; clientX: number; clientY: number } | null = null;
+    let activeCard: HTMLElement | null = null;
+
+    const reset = (card: HTMLElement) => {
+      TRACKED_PROPERTIES.forEach((property) => card.style.removeProperty(property));
+    };
+
+    const flush = () => {
+      frame = null;
+      const next = pending;
+      pending = null;
+      if (!next) {
+        return;
+      }
+
+      const { card, clientX, clientY } = next;
+      const rect = card.getBoundingClientRect();
+      if (rect.width === 0 || rect.height === 0) {
+        return;
+      }
+
+      const x = (clientX - rect.left) / rect.width;
+      const y = (clientY - rect.top) / rect.height;
+
+      card.style.setProperty("--mx", `${(x * 100).toFixed(2)}%`);
+      card.style.setProperty("--my", `${(y * 100).toFixed(2)}%`);
+      card.style.setProperty("--tilt-x", (x - 0.5).toFixed(4));
+      card.style.setProperty("--tilt-y", (y - 0.5).toFixed(4));
+    };
+
+    const handleMove = (event: PointerEvent) => {
+      // Hybrid machines report a fine pointer yet still emit touch events; a tap
+      // must not leave a card tilted with no way to un-hover it.
+      if (event.pointerType === "touch") {
+        return;
+      }
+
+      const target = event.target instanceof Element ? event.target : null;
+      const card = target?.closest<HTMLElement>(CARD_SELECTOR) ?? null;
+
+      if (card !== activeCard) {
+        if (activeCard) {
+          reset(activeCard);
+        }
+        activeCard = card;
+      }
+
+      if (!card) {
+        pending = null;
+        return;
+      }
+
+      pending = { card, clientX: event.clientX, clientY: event.clientY };
+      if (frame === null) {
+        frame = requestAnimationFrame(flush);
+      }
+    };
+
+    const handleLeave = () => {
+      pending = null;
+      if (activeCard) {
+        reset(activeCard);
+        activeCard = null;
+      }
+    };
+
+    grid.addEventListener("pointermove", handleMove, { passive: true });
+    grid.addEventListener("pointerleave", handleLeave);
+
+    return () => {
+      grid.removeEventListener("pointermove", handleMove);
+      grid.removeEventListener("pointerleave", handleLeave);
+      if (frame !== null) {
+        cancelAnimationFrame(frame);
+        frame = null;
+      }
+      handleLeave();
+    };
+  }, [gridRef]);
+}

--- a/components/sectionProjects/usePointerHologram.ts
+++ b/components/sectionProjects/usePointerHologram.ts
@@ -102,10 +102,14 @@ export function usePointerHologram(gridRef: RefObject<HTMLElement | null>): void
 
     grid.addEventListener("pointermove", handleMove, { passive: true });
     grid.addEventListener("pointerleave", handleLeave);
+    // The OS or an input device can take the gesture over mid-move; without
+    // this the card would stay tilted until the next pointermove.
+    grid.addEventListener("pointercancel", handleLeave);
 
     return () => {
       grid.removeEventListener("pointermove", handleMove);
       grid.removeEventListener("pointerleave", handleLeave);
+      grid.removeEventListener("pointercancel", handleLeave);
       if (frame !== null) {
         cancelAnimationFrame(frame);
         frame = null;

--- a/content/portfolioContent.test.ts
+++ b/content/portfolioContent.test.ts
@@ -58,6 +58,7 @@ describe("getPortfolioContent", () => {
       ["projects", "contextLabel"],
       ["projects", "contributionLabel"],
       ["projects", "outcomeLabel"],
+      ["projects", "disclosureLabel"],
       ["projects", "tagsAriaLabel"],
       ["projects", "externalLinkAriaTemplate"],
       ["projects", "externalLinkLabel"],

--- a/content/portfolioContent.ts
+++ b/content/portfolioContent.ts
@@ -150,6 +150,8 @@ export type PortfolioContent = {
     contextLabel: string;
     contributionLabel: string;
     outcomeLabel: string;
+    /** Visible label of the per-card `<details>` control holding context + contribution. */
+    disclosureLabel: string;
     tagsAriaLabel: string;
     externalLinkAriaTemplate: string;
     externalLinkLabel: string;
@@ -506,6 +508,7 @@ export const portfolioContent: Record<PortfolioLocale, PortfolioContent> = {
       contextLabel: "Contexte",
       contributionLabel: "Contribution",
       outcomeLabel: "Résultat",
+      disclosureLabel: "Contexte et contribution",
       tagsAriaLabel: "Technologies et compétences projet",
       externalLinkAriaTemplate: "Voir le site de {title} (lien externe)",
       externalLinkLabel: "Voir un lien public",
@@ -927,6 +930,7 @@ export const portfolioContent: Record<PortfolioLocale, PortfolioContent> = {
       contextLabel: "Context",
       contributionLabel: "Contribution",
       outcomeLabel: "Outcome",
+      disclosureLabel: "Context and contribution",
       tagsAriaLabel: "Project technologies and skills",
       externalLinkAriaTemplate: "View the {title} website (external link)",
       externalLinkLabel: "View public link",

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,7 +1,7 @@
 module.exports = {
   preset: "ts-jest",
   testEnvironment: "jsdom",
-  roots: ["<rootDir>/components", "<rootDir>/content", "<rootDir>/pages"],
+  roots: ["<rootDir>/components", "<rootDir>/content", "<rootDir>/lib", "<rootDir>/pages"],
   testMatch: ["**/*.test.ts", "**/*.test.tsx"],
   moduleFileExtensions: ["ts", "tsx", "js", "jsx", "json"],
   moduleNameMapper: {

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -22,17 +22,6 @@ jest.mock("next/link", () => ({
     React.createElement("a", { href, ...rest }, children),
 }));
 
-// next/dynamic resolves lazily and would pull in the heavy Spline WebGL runtime;
-// stub it to an inert component so hero tests stay fast and deterministic.
-jest.mock("next/dynamic", () => ({
-  __esModule: true,
-  default: () => {
-    const DynamicStub = () => null;
-    DynamicStub.displayName = "DynamicStub";
-    return DynamicStub;
-  },
-}));
-
 // jsdom does not implement matchMedia; default to "motion allowed".
 Object.defineProperty(window, "matchMedia", {
   writable: true,

--- a/lib/mediaPreferences.test.ts
+++ b/lib/mediaPreferences.test.ts
@@ -1,0 +1,40 @@
+import { hasFinePointer, prefersReducedMotion } from "./mediaPreferences";
+import { FINE_POINTER, NO_PREFERENCE, REDUCED_MOTION, mockMatchMedia } from "./testing/mockMatchMedia";
+
+describe("mediaPreferences", () => {
+  afterEach(() => mockMatchMedia(NO_PREFERENCE));
+
+  it("reports the reduced-motion preference when the query matches", () => {
+    mockMatchMedia(REDUCED_MOTION);
+
+    expect(prefersReducedMotion()).toBe(true);
+    expect(hasFinePointer()).toBe(false);
+  });
+
+  it("reports a fine pointer only when hover and precision are both available", () => {
+    mockMatchMedia(FINE_POINTER);
+
+    expect(hasFinePointer()).toBe(true);
+    expect(prefersReducedMotion()).toBe(false);
+  });
+
+  it("reports no preference when nothing matches", () => {
+    mockMatchMedia(NO_PREFERENCE);
+
+    expect(prefersReducedMotion()).toBe(false);
+    expect(hasFinePointer()).toBe(false);
+  });
+
+  it("answers conservatively where matchMedia is unavailable", () => {
+    // The SSR / older-jsdom path: neither probe may throw, and both must report
+    // the safe answer — no fine pointer, no motion preference expressed.
+    const original = window.matchMedia;
+    // @ts-expect-error deliberately simulating an environment without matchMedia
+    delete window.matchMedia;
+
+    expect(prefersReducedMotion()).toBe(false);
+    expect(hasFinePointer()).toBe(false);
+
+    window.matchMedia = original;
+  });
+});

--- a/lib/mediaPreferences.ts
+++ b/lib/mediaPreferences.ts
@@ -1,0 +1,35 @@
+/**
+ * Media-query probes shared by the decorative motion of the hero backdrop and
+ * the projects grid.
+ *
+ * They are read imperatively rather than kept in React state on purpose: both
+ * only gate whether an effect binds at all. A visitor flipping the OS setting
+ * mid-session picks up the new behaviour on the next mount, which is a fair
+ * trade for keeping these components free of extra media-query listeners.
+ *
+ * Every probe tolerates SSR and jsdom, where `window` or `matchMedia` may be
+ * missing, by reporting `false` — i.e. "no motion preference expressed" and
+ * "no fine pointer", the conservative answer in both cases.
+ */
+
+function mediaMatches(query: string): boolean {
+  return (
+    typeof window !== "undefined" &&
+    typeof window.matchMedia === "function" &&
+    window.matchMedia(query).matches
+  );
+}
+
+export function prefersReducedMotion(): boolean {
+  return mediaMatches("(prefers-reduced-motion: reduce)");
+}
+
+/**
+ * True only where the primary pointer both hovers and is precise — a mouse or a
+ * trackpad. Touch and stylus are deliberately excluded: pointer-tracked tilt and
+ * spotlight carry no meaning there and would leave a card stuck in its hovered
+ * state after a tap.
+ */
+export function hasFinePointer(): boolean {
+  return mediaMatches("(hover: hover) and (pointer: fine)");
+}

--- a/lib/testing/mockMatchMedia.ts
+++ b/lib/testing/mockMatchMedia.ts
@@ -1,0 +1,23 @@
+/**
+ * Test helper: jsdom implements no media queries, so components guarded by
+ * `matchMedia` need one injected. Callers declare which queries match.
+ *
+ * `jest.setup.ts` installs `window.matchMedia` as writable but not configurable,
+ * hence the plain assignment rather than `Object.defineProperty`.
+ */
+export function mockMatchMedia(matches: (query: string) => boolean): void {
+  window.matchMedia = ((query: string) => ({
+    matches: matches(query),
+    media: query,
+    onchange: null,
+    addListener: () => undefined,
+    removeListener: () => undefined,
+    addEventListener: () => undefined,
+    removeEventListener: () => undefined,
+    dispatchEvent: () => false,
+  })) as unknown as typeof window.matchMedia;
+}
+
+export const FINE_POINTER = (query: string) => query === "(hover: hover) and (pointer: fine)";
+export const REDUCED_MOTION = (query: string) => query === "(prefers-reduced-motion: reduce)";
+export const NO_PREFERENCE = () => false;

--- a/next.config.js
+++ b/next.config.js
@@ -9,9 +9,12 @@
 // per-request script nonce is not practical — hence the pragmatic 'unsafe-inline'):
 //   - style-src 'unsafe-inline'  → next/font + next/image inject inline styles
 //   - script-src 'unsafe-inline' → Next.js bootstrap + the gtag config script
-//   - 'wasm-unsafe-eval'         → the Spline WebGL runtime uses WebAssembly
-//   - connect-src prod.spline.design → the 3D scene fetch; *.google-analytics /
-//     vercel-insights → GA4 + Vercel Analytics beacons
+//   - connect-src *.google-analytics / vercel-insights → GA4 + Vercel Analytics
+//     beacons
+//
+// The 3D hero is gone (#68), and with it the two allowances it required:
+// 'wasm-unsafe-eval' in script-src (the Spline WebAssembly runtime) and
+// https://prod.spline.design in connect-src (the remote scene fetch).
 const contentSecurityPolicyReportOnly = [
   "default-src 'self'",
   "base-uri 'self'",
@@ -21,8 +24,8 @@ const contentSecurityPolicyReportOnly = [
   "img-src 'self' data:",
   "font-src 'self'",
   "style-src 'self' 'unsafe-inline'",
-  "script-src 'self' 'unsafe-inline' 'wasm-unsafe-eval' https://www.googletagmanager.com https://va.vercel-scripts.com https://www.google-analytics.com",
-  "connect-src 'self' https://prod.spline.design https://www.google-analytics.com https://*.google-analytics.com https://va.vercel-scripts.com https://vitals.vercel-insights.com",
+  "script-src 'self' 'unsafe-inline' https://www.googletagmanager.com https://va.vercel-scripts.com https://www.google-analytics.com",
+  "connect-src 'self' https://www.google-analytics.com https://*.google-analytics.com https://va.vercel-scripts.com https://vitals.vercel-insights.com",
   "worker-src 'self' blob:",
   "manifest-src 'self'",
   // `upgrade-insecure-requests` is intentionally omitted here: it is a no-op

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,6 @@
       "name": "valentinpasse-nextjs",
       "version": "0.1.0",
       "dependencies": {
-        "@splinetool/react-spline": "^4.1.0",
-        "@splinetool/runtime": "^1.12.97",
         "@vercel/analytics": "^2.0.1",
         "next": "^16.2.3",
         "react": "^19.2.4",
@@ -2411,37 +2409,6 @@
         "@sinonjs/commons": "^3.0.1"
       }
     },
-    "node_modules/@splinetool/react-spline": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@splinetool/react-spline/-/react-spline-4.1.0.tgz",
-      "integrity": "sha512-Y379gm17gw+1nxT/YXTCJnVIWuu7tsUH1tp/YxsYb0pZnc9Gljk7Om4Kpq7WPq0bZ4zidVCxf6xn6jgDcbHifQ==",
-      "dependencies": {
-        "blurhash": "2.0.5",
-        "lodash.debounce": "4.0.8",
-        "react-merge-refs": "2.1.1",
-        "thumbhash": "0.1.1"
-      },
-      "peerDependencies": {
-        "@splinetool/runtime": "*",
-        "next": ">=14.2.0",
-        "react": "*",
-        "react-dom": "*"
-      },
-      "peerDependenciesMeta": {
-        "next": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@splinetool/runtime": {
-      "version": "1.12.97",
-      "resolved": "https://registry.npmjs.org/@splinetool/runtime/-/runtime-1.12.97.tgz",
-      "integrity": "sha512-o+UeklU9n/d91E1YVaqPZLt6MzVOFhEUhmziCVRLWSEK8KmDRAVZljVst+kaVeSb5F4AcWZwhPVbT2rGwJYfEw==",
-      "dependencies": {
-        "on-change": "4.0.0",
-        "semver-compare": "1.0.0"
-      }
-    },
     "node_modules/@swc/helpers": {
       "version": "0.5.15",
       "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
@@ -3845,12 +3812,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/blurhash": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/blurhash/-/blurhash-2.0.5.tgz",
-      "integrity": "sha512-cRygWd7kGBQO3VEhPiTgq4Wc43ctsM+o46urrmPOiuAe+07fzlSB9OJVdpgDL0jPqXUVQ9ht7aq7kxOeJHRK+w==",
-      "license": "MIT"
     },
     "node_modules/brace-expansion": {
       "version": "1.1.15",
@@ -7520,12 +7481,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/lodash.debounce": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
-      "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==",
-      "license": "MIT"
-    },
     "node_modules/lodash.memoize": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
@@ -7998,18 +7953,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/on-change": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/on-change/-/on-change-4.0.0.tgz",
-      "integrity": "sha512-PTu7C9Jsz4b+sNMDpH0eZFTr7uxdOtoDWRnhaVNK50bgrrnW5nvbWI0jm5DG9qOoTnIhBzE9xoKVFPD9xgtbdg==",
-      "license": "MIT",
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/on-change?sponsor=1"
       }
     },
     "node_modules/once": {
@@ -8491,16 +8434,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/react-merge-refs": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/react-merge-refs/-/react-merge-refs-2.1.1.tgz",
-      "integrity": "sha512-jLQXJ/URln51zskhgppGJ2ub7b2WFKGq3cl3NYKtlHoTG+dN2q7EzWrn3hN3EgPsTMvpR9tpq5ijdp7YwFZkag==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/gregberge"
-      }
-    },
     "node_modules/readdirp": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
@@ -8796,12 +8729,6 @@
       "engines": {
         "node": ">=10"
       }
-    },
-    "node_modules/semver-compare": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
-      "integrity": "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==",
-      "license": "MIT"
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",
@@ -9395,12 +9322,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/thumbhash": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/thumbhash/-/thumbhash-0.1.1.tgz",
-      "integrity": "sha512-kH5pKeIIBPQXAOni2AiY/Cu/NKdkFREdpH+TLdM0g6WA7RriCv0kPLgP731ady67MhTAqrVG/4mnEeibVuCJcg==",
-      "license": "MIT"
     },
     "node_modules/tinyglobby": {
       "version": "0.2.16",
@@ -11723,26 +11644,6 @@
         "@sinonjs/commons": "^3.0.1"
       }
     },
-    "@splinetool/react-spline": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@splinetool/react-spline/-/react-spline-4.1.0.tgz",
-      "integrity": "sha512-Y379gm17gw+1nxT/YXTCJnVIWuu7tsUH1tp/YxsYb0pZnc9Gljk7Om4Kpq7WPq0bZ4zidVCxf6xn6jgDcbHifQ==",
-      "requires": {
-        "blurhash": "2.0.5",
-        "lodash.debounce": "4.0.8",
-        "react-merge-refs": "2.1.1",
-        "thumbhash": "0.1.1"
-      }
-    },
-    "@splinetool/runtime": {
-      "version": "1.12.97",
-      "resolved": "https://registry.npmjs.org/@splinetool/runtime/-/runtime-1.12.97.tgz",
-      "integrity": "sha512-o+UeklU9n/d91E1YVaqPZLt6MzVOFhEUhmziCVRLWSEK8KmDRAVZljVst+kaVeSb5F4AcWZwhPVbT2rGwJYfEw==",
-      "requires": {
-        "on-change": "4.0.0",
-        "semver-compare": "1.0.0"
-      }
-    },
     "@swc/helpers": {
       "version": "0.5.15",
       "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
@@ -12626,11 +12527,6 @@
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
       "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
       "devOptional": true
-    },
-    "blurhash": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/blurhash/-/blurhash-2.0.5.tgz",
-      "integrity": "sha512-cRygWd7kGBQO3VEhPiTgq4Wc43ctsM+o46urrmPOiuAe+07fzlSB9OJVdpgDL0jPqXUVQ9ht7aq7kxOeJHRK+w=="
     },
     "brace-expansion": {
       "version": "1.1.15",
@@ -15128,11 +15024,6 @@
         "p-locate": "^5.0.0"
       }
     },
-    "lodash.debounce": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
-      "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow=="
-    },
     "lodash.memoize": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
@@ -15437,11 +15328,6 @@
         "define-properties": "^1.2.1",
         "es-object-atoms": "^1.0.0"
       }
-    },
-    "on-change": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/on-change/-/on-change-4.0.0.tgz",
-      "integrity": "sha512-PTu7C9Jsz4b+sNMDpH0eZFTr7uxdOtoDWRnhaVNK50bgrrnW5nvbWI0jm5DG9qOoTnIhBzE9xoKVFPD9xgtbdg=="
     },
     "once": {
       "version": "1.4.0",
@@ -15748,11 +15634,6 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "dev": true
     },
-    "react-merge-refs": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/react-merge-refs/-/react-merge-refs-2.1.1.tgz",
-      "integrity": "sha512-jLQXJ/URln51zskhgppGJ2ub7b2WFKGq3cl3NYKtlHoTG+dN2q7EzWrn3hN3EgPsTMvpR9tpq5ijdp7YwFZkag=="
-    },
     "readdirp": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
@@ -15942,11 +15823,6 @@
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
       "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
       "devOptional": true
-    },
-    "semver-compare": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
-      "integrity": "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow=="
     },
     "set-function-length": {
       "version": "1.2.2",
@@ -16361,11 +16237,6 @@
         "glob": "^7.1.4",
         "minimatch": "^3.0.4"
       }
-    },
-    "thumbhash": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/thumbhash/-/thumbhash-0.1.1.tgz",
-      "integrity": "sha512-kH5pKeIIBPQXAOni2AiY/Cu/NKdkFREdpH+TLdM0g6WA7RriCv0kPLgP731ady67MhTAqrVG/4mnEeibVuCJcg=="
     },
     "tinyglobby": {
       "version": "0.2.16",

--- a/package.json
+++ b/package.json
@@ -13,8 +13,6 @@
     "build:og": "node scripts/build-og-image.mjs"
   },
   "dependencies": {
-    "@splinetool/react-spline": "^4.1.0",
-    "@splinetool/runtime": "^1.12.97",
     "@vercel/analytics": "^2.0.1",
     "next": "^16.2.3",
     "react": "^19.2.4",


### PR DESCRIPTION
Closes #68

Inverse l'équilibre visuel de la page : le hero s'allège, la section Projets devient le pic visuel.

Plan détaillé : [`docs/issues/68/plan.md`](https://github.com/val0m/valentinpasse-NextJS/blob/feat/68-hero-backdrop-bento-projets/docs/issues/68/plan.md)
Spec : [`docs/specs/hero-projects-redesign.md`](https://github.com/val0m/valentinpasse-NextJS/blob/Master/docs/specs/hero-projects-redesign.md)

## Ce qui est fait

Trois commits atomiques, dans l'ordre de séquencement demandé par l'issue.

### 1. `feat(projets)` — bento holographique
Bande dark pleine largeur, sortie du wrapper clair de `homePage.tsx` (le `<Hr/>` précédent disparaît, la bascule de surface porte la rupture). Grille bento 3 → 2 → 1 colonnes avec le projet 1 en 2×2 et des lignes explicites. `summary` et `outcome` restent hors interaction ; seuls `context` et `contribution` passent dans un `<details>` natif, donc toujours dans le DOM et crawlables.

Mécaniques holographiques réimplémentées en SCSS sur les tokens existants : tilt plafonné à 6°, spotlight curseur teinté accent, bordure conique animée via `@property`.

### 2. `perf(hero)` — backdrop CSS
`HeroBackground` → `HeroBackdrop` : deux blooms radiaux animés en `transform` seul, une grille de filets statique, un grain SVG. Disparaissent `Spline`, `SPLINE_SCENE`, `scheduleIdle`/`cancelIdle`, `supportsWebGL2`, `SplineErrorBoundary`, la boucle rAF de pointeurs synthétiques et les gates `IntersectionObserver`/`visibilitychange` — soit toute la surface de crash client traitée en #66 et #67.

### 3. `chore(deps)` — nettoyage + CSP
Deux dépendances retirées (8 paquets), `preconnect`/`dns-prefetch` supprimés, CSP raccourcie de `'wasm-unsafe-eval'` et `https://prod.spline.design`.

## Critères d'acceptation

**Hero**
- [x] Aucun WebGL, aucun `<canvas>`, aucun asset 3D distant
- [x] `HeroBackdrop` : dégradé dark + 2 blooms `transform`/`opacity` + grain SVG statique
- [x] `<h1>` opaque au premier paint — `animation: fadeInUp … both` retiré de `.content`, déplacé sur les actions et métriques
- [x] `min-height: clamp(560px, 82svh, 900px)` (avec repli `vh`)

**Projets**
- [x] Bande dark pleine largeur hors du wrapper clair, `<Hr/>` retiré
- [x] Bento 3/2/1 colonnes, projet 1 en 2×2, lignes explicites
- [x] `summary` + `outcome` toujours visibles, `context` + `contribution` en `<details>` natif
- [x] Tilt ≤ 6°, spotlight, bordure conique `@property` + repli statique
- [x] Un seul `pointermove` délégué, coalescé en un `requestAnimationFrame`
- [x] Lien externe uniquement si `publicLink` est défini

**Garde-fous**
- [x] Listeners montés uniquement si `(hover: hover) and (pointer: fine)`
- [x] Aucun listener sous `prefers-reduced-motion: reduce` ; effets aussi coupés en CSS
- [x] Accents en `--color-accent-on-dark` uniquement — `--color-accent` n'est utilisé que comme fond de CTA
- [x] Aucune propriété déclenchant du layout n'est animée
- [x] Aucune nouvelle dépendance runtime ; deux retirées

**Nettoyage**
- [x] `@splinetool/react-spline` + `@splinetool/runtime` retirés
- [x] `preconnect` / `dns-prefetch` retirés de `layout.tsx`
- [x] CSP : `'wasm-unsafe-eval'` et `https://prod.spline.design` retirés

## Refactos anti-duplication

- **`lib/mediaPreferences.ts`** — `prefersReducedMotion()` vivait dans `heroSection.tsx` et la section Projets en avait besoin, avec en plus une sonde `(hover: hover) and (pointer: fine)`. Les deux sondes `matchMedia` sont extraites plutôt que copiées, avec un point unique pour la tolérance SSR/jsdom. `lib` est ajouté aux `roots` de Jest.
- **`usePointerHologram`** colocalisé dans le dossier du composant : un seul consommateur aujourd'hui, extractible sans coût le jour où un second en a besoin.
- **Non appliqué, noté** : hero, Projets et Contact ont chacun leur paire de CTA sur fond dark aux styles très proches. La factorisation en composant partagé toucherait `sectionContact`, explicitement hors périmètre de l'issue.

## Tests

`111 tests / 10 suites` au vert, `npm run lint` et `npm run build` OK.

Ajoutés : les 11 scénarios unitaires de la spec (`sectionProjects.test.tsx`, `heroSection.test.tsx`) et les scénarios de composition/régression (`homePage.test.tsx` — hero en premier, Projets hors du wrapper clair, ancres intactes, parité FR/EN, absence de dépendance Spline, CSP, hints du head, absence de canvas).

Trois assertions portent sur le source SCSS plutôt que sur le DOM (`.content` non animé, `min-height` en `svh`, drift coupé en reduced-motion) : jsdom ne calcule pas les styles, et ce sont exactement les régressions que la spec demande de verrouiller.

## Restant à la charge de l'utilisateur

Vérifications manuelles non automatisables ici : Lighthouse mobile avant/après contre la baseline LCP 3,0–4,5 s, rendu à 375/768/1024/1440 px + paysage, tactile, clavier seul, `prefers-reduced-motion`, et Firefox/Safari dont un navigateur sans `@property` pour valider le repli de bordure.

## Comportement à connaître

Déplier un `<details>` fait grandir la carte : les cartes voisines de la même rangée gardent leur position, mais le contenu situé dessous descend — comportement inhérent à une divulgation native. Le nombre de pistes de la grille est figé (`grid-template-rows` explicite), donc le bento ne se réorganise jamais.

🤖 Generated with [Claude Code](https://claude.com/claude-code)